### PR TITLE
feat: Implementar ingreso de asistencia para fechas históricas

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import TeacherScoresPage from './pages/TeacherScoresPage';
 import TeacherSummaryPage from './pages/TeacherSummaryPage';
 import TeacherRankingPage from './pages/TeacherRankingPage';
 import TeacherDatabasePage from './pages/TeacherDatabasePage'; // Nueva página de Base de Datos (Docente)
+import TeacherHistoricAttendancePage from './pages/TeacherHistoricAttendancePage'; // <-- Nueva importación
 import StudentLoginPage from './pages/StudentLoginPage';
 import StudentDashboardPage from './pages/StudentDashboardPage';
 import StudentScoresDetailPage from './pages/StudentScoresDetailPage';
@@ -59,6 +60,7 @@ function App() {
               <Route path="/docente/puntuaciones" element={<TeacherScoresPage />} />
               <Route path="/docente/resumen" element={<TeacherSummaryPage />} />
               <Route path="/docente/ranking" element={<TeacherRankingPage />} />
+              <Route path="/docente/ingreso-historico" element={<TeacherHistoricAttendancePage />} /> {/* <-- Nueva ruta */}
               {/* Aquí se añadirán más rutas protegidas para el docente en el futuro */}
             </Route>
 

--- a/frontend/src/pages/TeacherAttendancePage.jsx
+++ b/frontend/src/pages/TeacherAttendancePage.jsx
@@ -4,27 +4,21 @@ import { Link } from 'react-router-dom';
 
 // Función para obtener la hora actual en Perú (Lima, UTC-5)
 const getCurrentPeruDateTimeObject = () => {
-  // Usamos el objeto Intl.DateTimeFormat para obtener las partes de la fecha y hora en la zona horaria de Perú.
-  // Esto es más robusto que los cálculos manuales de offset.
   const now = new Date();
   const options = {
     timeZone: 'America/Lima',
     year: 'numeric', month: 'numeric', day: 'numeric',
     hour: 'numeric', minute: 'numeric', second: 'numeric',
-    hour12: false // Usar formato de 24 horas para facilitar la lógica
+    hour12: false
   };
-  const formatter = new Intl.DateTimeFormat('en-CA', options); // 'en-CA' da YYYY-MM-DD, HH:MM:SS
+  const formatter = new Intl.DateTimeFormat('en-CA', options);
   const parts = formatter.formatToParts(now);
-
   const dateParts = {};
   for (const part of parts) {
     if (part.type !== 'literal') {
       dateParts[part.type] = parseInt(part.value, 10);
     }
   }
-  // Crear un nuevo objeto Date a partir de las partes. OJO: Esto lo crea en la zona horaria local del navegador
-  // pero los valores numéricos corresponden a Perú. La lógica de comparación horaria deberá usar estos valores numéricos.
-  // O, mejor aún, la función puede devolver directamente los componentes numéricos.
   return new Date(dateParts.year, dateParts.month - 1, dateParts.day, dateParts.hour, dateParts.minute, dateParts.second);
 };
 
@@ -41,55 +35,63 @@ const STATUS_DISPLAY_MAP = {
 const getDisplayableAttendanceInfo = (status, points_earned = 0, base_attendance_points = 0) => {
   const displayInfo = STATUS_DISPLAY_MAP[status] || { text: status, basePoints: 0 };
   let totalPoints = 0;
-
   if (status && !status.startsWith('AUSENCIA') && status !== 'NO_REGISTRADO') {
     totalPoints = (points_earned || 0) + (base_attendance_points || 0);
-  } else if (status) { // Para ausencias, los puntos ya están en points_earned
+  } else if (status) {
     totalPoints = (points_earned || 0);
   }
-
   return `${displayInfo.text} (${totalPoints >= 0 ? '+' : ''}${totalPoints} pts)`;
 };
 
-
-const TeacherAttendancePage = () => {
+// 1. Aceptar prop selectedDate (renombrada a historicDateProp para claridad interna)
+const TeacherAttendancePage = ({ selectedDate: historicDateProp }) => {
   const [students, setStudents] = useState([]);
-  const [allStudents, setAllStudents] = useState([]); // Para mantener la lista original sin filtrar
+  const [allStudents, setAllStudents] = useState([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [currentPeruDateTime, setCurrentPeruDateTime] = useState(getCurrentPeruDateTimeObject());
-  const [attendanceData, setAttendanceData] = useState({}); // { student_id: { status: 'PUNTUAL', notes: '' } }
+  const [attendanceData, setAttendanceData] = useState({});
   const [dailyStatus, setDailyStatus] = useState({ attendance_records: [], bonus_awarded_today: null });
 
-  // Estado para el modal de tardanza
   const [tardanzaModalOpen, setTardanzaModalOpen] = useState(false);
-  const [tardanzaStudent, setTardanzaStudent] = useState(null); // { id, name }
-  const [tardanzaJustification, setTardanzaJustification] = useState(''); // 'JUSTIFICADA' o 'INJUSTIFICADA'
+  const [tardanzaStudent, setTardanzaStudent] = useState(null);
+  const [tardanzaJustification, setTardanzaJustification] = useState('');
   const [tardanzaNotes, setTardanzaNotes] = useState('');
 
-  // Estado para el bono madrugador
   const [selectedStudentForBonus, setSelectedStudentForBonus] = useState('');
 
-  // Estados para el modal de Cierre de Asistencia
   const [closeAttendanceModalOpen, setCloseAttendanceModalOpen] = useState(false);
-  const [absentStudentsForModal, setAbsentStudentsForModal] = useState([]); // [{id, full_name, nickname}]
-  const [absentJustifications, setAbsentJustifications] = useState({}); // { student_id: { is_justified: false, notes: '' } }
-
+  const [absentStudentsForModal, setAbsentStudentsForModal] = useState([]);
+  const [absentJustifications, setAbsentJustifications] = useState({});
 
   const API_URL = 'http://localhost:3001/api';
-  // Obtener la fecha de hoy en formato YYYY-MM-DD para la zona horaria de Perú
-  const getTodayPeruDateString = () => {
-    const nowInPeru = getCurrentPeruDateTimeObject(); // Esta función ya devuelve un objeto Date con valores de Perú
+
+  const getTodayPeruDateString = useCallback(() => {
+    const nowInPeru = getCurrentPeruDateTimeObject();
     const year = nowInPeru.getFullYear();
     const month = (nowInPeru.getMonth() + 1).toString().padStart(2, '0');
     const day = nowInPeru.getDate().toString().padStart(2, '0');
     return `${year}-${month}-${day}`;
-  };
-  const [todayDateString, setTodayDateString] = useState(getTodayPeruDateString());
+  }, []);
+
+  // 2. Determinar la fecha a usar: prop si existe, si no, la fecha actual de Perú.
+  const [dateForOperations, setDateForOperations] = useState(historicDateProp || getTodayPeruDateString());
+
+  useEffect(() => {
+    if (historicDateProp) {
+      setDateForOperations(historicDateProp);
+    } else {
+      setDateForOperations(getTodayPeruDateString());
+    }
+    // Resetear estados que dependen de la fecha cuando esta cambia
+    setDailyStatus({ attendance_records: [], bonus_awarded_today: null });
+    setAttendanceData({});
+    setSelectedStudentForBonus('');
+    // No es necesario resetear `students` o `allStudents` ya que la lista de estudiantes activos no cambia con la fecha.
+  }, [historicDateProp, getTodayPeruDateString]);
 
 
-  // Obtener token
   const getToken = useCallback(() => localStorage.getItem('teacherToken'), []);
 
   // Cargar estudiantes y estado de asistencia del día
@@ -101,45 +103,47 @@ const TeacherAttendancePage = () => {
         const token = getToken();
         const headers = { 'x-auth-token': token };
 
-        // 1. Obtener lista de todos los estudiantes ACTIVOS
         const studentsResponse = await axios.get(`${API_URL}/admin/students?active=true`, { headers });
         setAllStudents(studentsResponse.data);
-        setStudents(studentsResponse.data); // Inicialmente mostrar todos
+        setStudents(studentsResponse.data);
 
-        // 2. Obtener estado de asistencia del día
-        const dailyStatusResponse = await axios.get(`${API_URL}/attendance/status/${todayDateString}`, { headers });
+        // Usar dateForOperations para obtener el estado de asistencia
+        const dailyStatusResponse = await axios.get(`${API_URL}/attendance/status/${dateForOperations}`, { headers });
         setDailyStatus(dailyStatusResponse.data);
 
-        // Pre-rellenar attendanceData con los registros existentes
         const initialAttendance = {};
         dailyStatusResponse.data.attendance_records.forEach(record => {
           initialAttendance[record.student_id] = {
             status: record.status,
             notes: record.notes || '',
-            is_synced: true // Marcar como ya guardado
+            is_synced: true
           };
         });
         setAttendanceData(initialAttendance);
 
       } catch (err) {
-        console.error("Error fetching initial data:", err);
+        console.error(`Error fetching initial data for date ${dateForOperations}:`, err);
         setError(err.response?.data?.message || err.message || 'Error al cargar datos iniciales.');
       } finally {
         setLoading(false);
       }
     };
     fetchData();
-  }, [getToken, todayDateString]);
+  }, [getToken, dateForOperations]); // 3. Usar dateForOperations en dependencias
 
-  // Actualizar hora de Perú cada segundo
+  // Actualizar hora de Perú cada segundo (solo si no es una fecha histórica)
   useEffect(() => {
-    const timer = setInterval(() => {
-      setCurrentPeruDateTime(getCurrentPeruDateTimeObject());
-    }, 1000);
-    return () => clearInterval(timer);
-  }, []);
+    let timer;
+    if (!historicDateProp) {
+      timer = setInterval(() => {
+        setCurrentPeruDateTime(getCurrentPeruDateTimeObject());
+      }, 1000);
+    }
+    return () => {
+      if (timer) clearInterval(timer);
+    };
+  }, [historicDateProp]);
 
-  // Filtrar estudiantes
   useEffect(() => {
     if (!searchTerm) {
       setStudents(allStudents);
@@ -159,44 +163,37 @@ const TeacherAttendancePage = () => {
       [studentId]: {
         ...prev[studentId],
         [field]: value,
-        is_synced: false, // Marcar como no guardado al cambiar
+        is_synced: false,
       }
     }));
   };
 
   const getPeruTimeForAttendance = () => {
-    // Esta función determinaría la hora actual al momento de marcar la asistencia
-    // Para la lógica PUNTUAL, A_TIEMPO, TARDANZA
-    // Por ahora, usaremos la hora actual del estado `currentPeruDateTime`
-    // En una implementación más compleja, se podría tomar un snapshot al momento del click.
     return currentPeruDateTime;
   };
 
-  const determineStatusBasedOnTime = () => { // Ya no necesita studentId aquí
+  const determineStatusBasedOnTime = () => {
+    // 4. Lógica de status basada en tiempo solo si NO es una fecha histórica
+    if (historicDateProp) {
+      // Para fechas históricas, el docente debe elegir el estado.
+      // Forzamos 'TARDANZA' para que se abra el modal, donde el profesor puede seleccionar.
+      // Esta es una simplificación; un mejor enfoque sería un modal más genérico o un selector directo.
+      return 'TARDANZA';
+    }
+
     const nowPeru = getPeruTimeForAttendance();
-    // Asegurarse que getHours() y getMinutes() se aplican al objeto Date correcto
-    // currentPeruDateTime ya es el objeto Date con los valores de Perú
-    const hours = currentPeruDateTime.getHours();
+    const hours = nowPeru.getHours();
     const minutes = nowPeru.getMinutes();
 
-    // Lógica de horas:
-    // Puntual (antes de las 5:00 pm => 17:00): +2 puntos por puntualidad.
-    // A Tiempo (entre 5:00 y 5:15 pm => 17:00 - 17:15): +1 punto.
-    // Tardanza (después de las 5:15 pm => 17:15): Debe abrir un diálogo...
-
-    if (hours < 17) { // Antes de las 5 PM
-        return 'PUNTUAL';
-    } else if (hours === 17 && minutes <= 15) { // Entre 5:00 PM y 5:15 PM
-        return 'A_TIEMPO';
-    } else { // Después de las 5:15 PM
-        return 'TARDANZA'; // Este estado requerirá un sub-dialogo (Justificada/Injustificada)
-    }
+    if (hours < 17) { return 'PUNTUAL'; }
+    else if (hours === 17 && minutes <= 15) { return 'A_TIEMPO'; }
+    else { return 'TARDANZA'; }
   };
 
   const handleOpenTardanzaModal = (student) => {
     setTardanzaStudent(student);
-    setTardanzaNotes(attendanceData[student.id]?.notes || ''); // Cargar notas existentes si las hay
-    setTardanzaJustification(''); // Resetear justificación
+    setTardanzaNotes(attendanceData[student.id]?.notes || '');
+    setTardanzaJustification('');
     setTardanzaModalOpen(true);
   };
 
@@ -213,79 +210,71 @@ const TeacherAttendancePage = () => {
       return;
     }
     const statusToSave = tardanzaJustification === 'JUSTIFICADA' ? 'TARDANZA_JUSTIFICADA' : 'TARDANZA_INJUSTIFICADA';
-    // Llamar a la función principal de guardado con el estado de tardanza y las notas
     saveAttendanceRecord(tardanzaStudent.id, statusToSave, tardanzaNotes);
     handleCloseTardanzaModal();
   };
 
-  // Función refactorizada para guardar/actualizar el registro de asistencia
   const saveAttendanceRecord = async (studentId, status, notes) => {
     try {
       const token = getToken();
       const response = await axios.post(`${API_URL}/attendance/record`, {
         student_id: studentId,
-        attendance_date: todayDateString,
+        attendance_date: dateForOperations, // <-- 5. Usar dateForOperations
         status: status,
         notes: notes,
       }, { headers: { 'x-auth-token': token } });
 
-      // Actualizar estado local
       setAttendanceData(prev => ({
         ...prev,
         [studentId]: { status: status, notes: notes, is_synced: true }
       }));
 
-      // Actualizar dailyStatus para reflejar el cambio inmediatamente
       setDailyStatus(prev => {
-        const studentInfo = allStudents.find(s => s.id === studentId); // Cambiado a studentInfo para claridad
+        const studentInfo = allStudents.find(s => s.id === studentId);
         const updatedRecords = prev.attendance_records.filter(r => r.student_id !== studentId);
         updatedRecords.push({
-            student_id: studentId,
-            status: status,
-            notes: notes,
-            full_name: studentInfo?.full_name || 'Desconocido', // Fallback
-            nickname: studentInfo?.nickname || '', // Fallback
+            student_id: studentId, status: status, notes: notes,
+            full_name: studentInfo?.full_name || 'Desconocido',
+            nickname: studentInfo?.nickname || '',
             points_earned: response.data.record.points_earned,
             base_attendance_points: response.data.record.base_attendance_points,
             recorded_at: response.data.record.recorded_at,
         });
-        // Ordenar para mantener consistencia si se desea
-        // updatedRecords.sort((a, b) => (a.full_name || "").localeCompare(b.full_name || ""));
-        return { ...prev, attendance_records: updatedRecords };
+        return { ...prev, attendance_records: updatedRecords.sort((a,b) => (a.full_name || "").localeCompare(b.full_name || "")) };
       });
 
       const studentInfoForAlert = allStudents.find(s => s.id === studentId);
       const studentNameForAlert = studentInfoForAlert?.full_name || studentId;
-      alert(`Asistencia para ${studentNameForAlert} registrada como ${status}.`);
+      alert(`Asistencia para ${studentNameForAlert} (${dateForOperations}) registrada como ${status}.`);
 
     } catch (err) {
       console.error("Error saving attendance:", err);
       const errorMsg = err.response?.data?.message || err.message || 'Error al guardar asistencia.';
       setError(errorMsg);
-      alert(`Error al guardar: ${errorMsg}`); // Mostrar alerta al usuario
-      // Considerar revertir el cambio optimista si es necesario, aunque aquí el estado se actualiza post-llamada.
-      // Si `is_synced` se usara para UI optimista, aquí se resetearía.
+      alert(`Error al guardar: ${errorMsg}`);
     }
   };
 
-
   const handleProcessAttendanceClick = (student) => {
     const timeBasedStatus = determineStatusBasedOnTime();
-    if (timeBasedStatus === 'TARDANZA') {
+    if (timeBasedStatus === 'TARDANZA') { // Esto incluye el caso de historicDateProp
       handleOpenTardanzaModal(student);
     } else {
-      // Para PUNTUAL o A_TIEMPO, se guardan directamente sin notas adicionales (a menos que ya existan)
+      // Este bloque solo se ejecutará si no es historicDateProp y el tiempo es PUNTUAL o A_TIEMPO
       const currentNotes = attendanceData[student.id]?.notes || '';
       saveAttendanceRecord(student.id, timeBasedStatus, currentNotes);
     }
   };
 
   const handleApplyEarlyBonus = async () => {
+    if (historicDateProp) { // No permitir bono en fechas históricas
+        alert("El bono madrugador solo se puede aplicar en la fecha actual.");
+        return;
+    }
     if (!selectedStudentForBonus) {
       alert("Por favor, seleccione un estudiante para otorgar el bono.");
       return;
     }
-
     if (dailyStatus.bonus_awarded_today) {
       alert(`El bono madrugador ya fue otorgado a ${dailyStatus.bonus_awarded_today.bonus_student_name}.`);
       return;
@@ -295,10 +284,9 @@ const TeacherAttendancePage = () => {
       const token = getToken();
       const response = await axios.post(`${API_URL}/attendance/early-bonus`, {
         student_id: selectedStudentForBonus,
-        bonus_date: todayDateString,
+        bonus_date: dateForOperations, // <-- 6. Usar dateForOperations (será la fecha actual aquí)
       }, { headers: { 'x-auth-token': token } });
 
-      // Actualizar el estado de dailyStatus para reflejar que el bono fue otorgado
       setDailyStatus(prev => ({
         ...prev,
         bonus_awarded_today: {
@@ -307,13 +295,13 @@ const TeacherAttendancePage = () => {
           points_awarded: response.data.bonus_record.points_awarded,
         }
       }));
-      setSelectedStudentForBonus(''); // Limpiar selección
+      setSelectedStudentForBonus('');
       alert(`Bono madrugador otorgado a ${allStudents.find(s => s.id === response.data.bonus_record.student_id)?.full_name || selectedStudentForBonus}.`);
 
     } catch (err) {
       console.error("Error applying early bonus:", err);
       const errorMsg = err.response?.data?.message || err.message || 'Error al aplicar el bono madrugador.';
-      setError(errorMsg); // Podría mostrarse en un área de error general
+      setError(errorMsg);
       alert(`Error al aplicar bono: ${errorMsg}`);
     }
   };
@@ -321,10 +309,7 @@ const TeacherAttendancePage = () => {
   const handleOpenCloseAttendanceModal = () => {
     const recordedStudentIds = new Set(dailyStatus.attendance_records.map(r => r.student_id));
     const absent = allStudents.filter(student => !recordedStudentIds.has(student.id));
-
     setAbsentStudentsForModal(absent);
-
-    // Inicializar justificaciones para los ausentes
     const initialJustifications = {};
     absent.forEach(student => {
       initialJustifications[student.id] = { is_justified: false, notes: '' };
@@ -333,58 +318,42 @@ const TeacherAttendancePage = () => {
     setCloseAttendanceModalOpen(true);
   };
 
-  const handleCloseModalOfAttendance = () => { // Renombrado para evitar conflicto
+  const handleCloseModalOfAttendance = () => {
     setCloseAttendanceModalOpen(false);
-    // No resetear absentStudentsForModal o absentJustifications aquí si queremos que se mantengan
-    // si el modal se cierra y se vuelve a abrir sin un submit. O sí resetearlos si es preferible.
   };
 
   const handleAbsentJustificationChange = (studentId, field, value) => {
     setAbsentJustifications(prev => ({
       ...prev,
-      [studentId]: {
-        ...prev[studentId],
-        [field]: value,
-      }
+      [studentId]: { ...prev[studentId], [field]: value, }
     }));
   };
 
   const handleSubmitCloseAttendance = async () => {
     const justificationsPayload = Object.entries(absentJustifications)
-      .map(([student_id, data]) => ({
-        student_id,
-        is_justified: data.is_justified,
-        notes: data.notes,
-      }));
+      .map(([student_id, data]) => ({ student_id, is_justified: data.is_justified, notes: data.notes, }));
 
     try {
       const token = getToken();
       const response = await axios.post(`${API_URL}/attendance/close`, {
-        attendance_date: todayDateString,
+        attendance_date: dateForOperations, // <-- 7. Usar dateForOperations
         absent_students_justifications: justificationsPayload,
       }, { headers: { 'x-auth-token': token } });
 
       alert(response.data.message || "Cierre de asistencia procesado.");
 
-      // Refrescar el estado diario para incluir los nuevos registros de ausencia
-      const updatedDailyStatusResponse = await axios.get(`${API_URL}/attendance/status/${todayDateString}`, { headers: { 'x-auth-token': token } });
+      const updatedDailyStatusResponse = await axios.get(`${API_URL}/attendance/status/${dateForOperations}`, { headers: { 'x-auth-token': token } });
       setDailyStatus(updatedDailyStatusResponse.data);
-       // Pre-rellenar attendanceData con los registros existentes, incluyendo las nuevas ausencias
-      const newAttendanceData = { ...attendanceData }; // Mantener los registros que ya estaban
+      const newAttendanceData = { ...attendanceData };
       updatedDailyStatusResponse.data.attendance_records.forEach(record => {
-        if (!newAttendanceData[record.student_id] || record.status.startsWith("AUSENCIA")) { // Solo añadir/sobrescribir si es nuevo o es una ausencia
+        if (!newAttendanceData[record.student_id] || record.status.startsWith("AUSENCIA")) {
              newAttendanceData[record.student_id] = {
-                status: record.status,
-                notes: record.notes || '',
-                is_synced: true
+                status: record.status, notes: record.notes || '', is_synced: true
              };
         }
       });
       setAttendanceData(newAttendanceData);
-
       setCloseAttendanceModalOpen(false);
-      // Aquí se podría setear un estado `isAttendanceClosedForToday = true` si el backend lo confirma.
-      // Por ahora, la UI se actualizará con los nuevos datos.
 
     } catch (err) {
       console.error("Error closing attendance:", err);
@@ -394,51 +363,33 @@ const TeacherAttendancePage = () => {
     }
   };
 
-  if (loading) return <p>Cargando datos de asistencia...</p>;
+  if (loading) return <p>Cargando datos de asistencia para {dateForOperations}...</p>;
   if (error) return <div><p>Error: {error}</p><Link to="/docente/dashboard">Volver al Panel</Link></div>;
 
-  // Modal para Tardanza
   const renderTardanzaModal = () => {
     if (!tardanzaModalOpen || !tardanzaStudent) return null;
-
+    // 8. Adaptar título del modal de tardanza si es histórico
+    const modalTitle = historicDateProp
+        ? `Registrar Estado para: ${tardanzaStudent.full_name} (${tardanzaStudent.id}) - Fecha: ${dateForOperations}`
+        : `Registrar Tardanza para: ${tardanzaStudent.full_name} (${tardanzaStudent.id})`;
     return (
       <div className="modal-overlay">
         <div className="modal-content">
-          <h3>Registrar Tardanza para: {tardanzaStudent.full_name} ({tardanzaStudent.id})</h3>
+          <h3>{modalTitle}</h3>
           <div>
             <label>
-              <input
-                type="radio"
-                name="justification"
-                value="JUSTIFICADA"
-                checked={tardanzaJustification === 'JUSTIFICADA'}
-                onChange={(e) => setTardanzaJustification(e.target.value)}
-              />
-              Justificada
+              <input type="radio" name="justification" value="JUSTIFICADA" checked={tardanzaJustification === 'JUSTIFICADA'} onChange={(e) => setTardanzaJustification(e.target.value)} /> Justificada
             </label>
             <label style={{ marginLeft: '10px' }}>
-              <input
-                type="radio"
-                name="justification"
-                value="INJUSTIFICADA"
-                checked={tardanzaJustification === 'INJUSTIFICADA'}
-                onChange={(e) => setTardanzaJustification(e.target.value)}
-              />
-              Injustificada
+              <input type="radio" name="justification" value="INJUSTIFICADA" checked={tardanzaJustification === 'INJUSTIFICADA'} onChange={(e) => setTardanzaJustification(e.target.value)} /> Injustificada
             </label>
           </div>
           <div style={{ marginTop: '10px' }}>
             <label htmlFor="tardanzaNotes">Notas:</label>
-            <textarea
-              id="tardanzaNotes"
-              value={tardanzaNotes}
-              onChange={(e) => setTardanzaNotes(e.target.value)}
-              rows="3"
-              style={{ width: '90%', marginTop: '5px' }}
-            />
+            <textarea id="tardanzaNotes" value={tardanzaNotes} onChange={(e) => setTardanzaNotes(e.target.value)} rows="3" style={{ width: '90%', marginTop: '5px' }} />
           </div>
           <div style={{ marginTop: '15px' }}>
-            <button onClick={handleSubmitTardanzaModal}>Guardar Tardanza</button>
+            <button onClick={handleSubmitTardanzaModal}>Guardar</button>
             <button onClick={handleCloseTardanzaModal} style={{ marginLeft: '10px' }}>Cancelar</button>
           </div>
         </div>
@@ -447,64 +398,36 @@ const TeacherAttendancePage = () => {
   };
 
   const isAllStudentsRecorded = () => {
-    if (!allStudents || allStudents.length === 0) return false; // No hay estudiantes para registrar
+    if (!allStudents || allStudents.length === 0) return false;
     const recordedStudentIds = new Set(dailyStatus.attendance_records.map(r => r.student_id));
     return allStudents.every(student => recordedStudentIds.has(student.id));
   };
 
-  // Considerar que la asistencia está "cerrada" si todos los estudiantes tienen un registro.
-  // Una lógica más robusta podría venir del backend o un estado explícito.
   const isAttendanceEffectivelyClosed = isAllStudentsRecorded();
 
-
-  // Modal para Cierre de Asistencia
   const renderCloseAttendanceModal = () => {
     if (!closeAttendanceModalOpen) return null;
-
     return (
       <div className="modal-overlay">
         <div className="modal-content">
-          <h3>Cerrar Asistencia del Día: {todayDateString}</h3>
+          <h3>Cerrar Asistencia del Día: {dateForOperations}</h3>
           <p>Los siguientes estudiantes no tienen un registro de asistencia. Por favor, marque sus ausencias:</p>
-          {absentStudentsForModal.length === 0 ? (
-            <p>Todos los estudiantes ya tienen un registro.</p>
-          ) : (
+          {absentStudentsForModal.length === 0 ? (<p>Todos los estudiantes ya tienen un registro.</p>) : (
             <table>
-              <thead>
-                <tr>
-                  <th>Estudiante</th>
-                  <th>Justificada</th>
-                  <th>Notas</th>
-                </tr>
-              </thead>
+              <thead><tr><th>Estudiante</th><th>Justificada</th><th>Notas</th></tr></thead>
               <tbody>
                 {absentStudentsForModal.map(student => (
                   <tr key={student.id}>
                     <td>{student.full_name} ({student.id})</td>
-                    <td>
-                      <input
-                        type="checkbox"
-                        checked={absentJustifications[student.id]?.is_justified || false}
-                        onChange={(e) => handleAbsentJustificationChange(student.id, 'is_justified', e.target.checked)}
-                      />
-                    </td>
-                    <td>
-                      <input
-                        type="text"
-                        value={absentJustifications[student.id]?.notes || ''}
-                        onChange={(e) => handleAbsentJustificationChange(student.id, 'notes', e.target.value)}
-                        placeholder="Motivo (opcional)"
-                      />
-                    </td>
+                    <td><input type="checkbox" checked={absentJustifications[student.id]?.is_justified || false} onChange={(e) => handleAbsentJustificationChange(student.id, 'is_justified', e.target.checked)} /></td>
+                    <td><input type="text" value={absentJustifications[student.id]?.notes || ''} onChange={(e) => handleAbsentJustificationChange(student.id, 'notes', e.target.value)} placeholder="Motivo (opcional)" /></td>
                   </tr>
                 ))}
               </tbody>
             </table>
           )}
           <div style={{ marginTop: '15px' }}>
-            <button onClick={handleSubmitCloseAttendance} disabled={absentStudentsForModal.length === 0}>
-              Confirmar Cierre y Registrar Ausencias
-            </button>
+            <button onClick={handleSubmitCloseAttendance} disabled={absentStudentsForModal.length === 0}>Confirmar Cierre y Registrar Ausencias</button>
             <button onClick={handleCloseModalOfAttendance} style={{ marginLeft: '10px' }}>Cancelar</button>
           </div>
         </div>
@@ -512,21 +435,22 @@ const TeacherAttendancePage = () => {
     );
   };
 
-
   return (
     <div>
-      <h2>Registrar Asistencia</h2>
-      <p>Fecha y Hora (Perú): {currentPeruDateTime.toLocaleString('es-PE', { dateStyle: 'full', timeStyle: 'medium' })}</p>
-      <p>Fecha para registros: {todayDateString}</p>
-      <Link to="/docente/dashboard">Volver al Panel</Link>
+      {/* 9. Ocultar/mostrar elementos UI específicos si es histórico */}
+      {!historicDateProp && (
+        <>
+          <h2>Registrar Asistencia</h2>
+          <p>Fecha y Hora (Perú): {currentPeruDateTime.toLocaleString('es-PE', { dateStyle: 'full', timeStyle: 'medium' })}</p>
+          <Link to="/docente/dashboard">Volver al Panel</Link>
+        </>
+      )}
+      <p style={{ fontWeight: 'bold', color: historicDateProp ? 'blue' : 'inherit' }}>
+        Fecha para registros: {dateForOperations}
+      </p>
 
       <div>
-        <input
-          type="text"
-          placeholder="Buscar estudiante por ID o nombre..."
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-        />
+        <input type="text" placeholder="Buscar estudiante por ID o nombre..." value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} />
       </div>
 
       <div style={{ margin: '20px 0' }}>
@@ -540,62 +464,38 @@ const TeacherAttendancePage = () => {
             <select
               value={selectedStudentForBonus}
               onChange={(e) => setSelectedStudentForBonus(e.target.value)}
-              disabled={!!dailyStatus.bonus_awarded_today || isAttendanceEffectivelyClosed}
+              disabled={!!dailyStatus.bonus_awarded_today || isAttendanceEffectivelyClosed || historicDateProp} // <-- 10. Deshabilitar bono para fechas históricas
             >
               <option value="">Seleccione un estudiante</option>
               {allStudents
                 .filter(student => {
-                  // Incluir solo estudiantes que tienen un registro de asistencia y no es ausencia
                   const attendanceRecord = dailyStatus.attendance_records.find(r => r.student_id === student.id);
                   return attendanceRecord && !attendanceRecord.status.startsWith('AUSENCIA');
                 })
-                .map(student => (
-                  <option key={student.id} value={student.id}>
-                    {student.full_name} ({student.id})
-                  </option>
-                ))}
+                .map(student => (<option key={student.id} value={student.id}>{student.full_name} ({student.id})</option>))}
             </select>
-            <button
-              onClick={handleApplyEarlyBonus}
-              disabled={!selectedStudentForBonus || !!dailyStatus.bonus_awarded_today || isAttendanceEffectivelyClosed}
-              style={{ marginLeft: '10px' }}
-            >
+            <button onClick={handleApplyEarlyBonus} disabled={!selectedStudentForBonus || !!dailyStatus.bonus_awarded_today || isAttendanceEffectivelyClosed || historicDateProp} style={{ marginLeft: '10px' }}>
               Otorgar Bono Madrugador
             </button>
           </div>
         )}
+        {historicDateProp && <p style={{color: 'orange', marginTop: '5px'}}>El bono madrugador solo se puede otorgar el día actual.</p>}
       </div>
 
       <table>
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Nombre Completo</th>
-            <th>Apodo</th>
-            <th>Estado Actual</th>
-            <th>Acciones</th>
-            <th>Notas</th>
-          </tr>
-        </thead>
+        <thead><tr><th>ID</th><th>Nombre Completo</th><th>Apodo</th><th>Estado Actual</th><th>Acciones</th><th>Notas</th></tr></thead>
         <tbody>
           {students.map(student => {
             const currentStudentAttendance = attendanceData[student.id] || { status: 'NO_REGISTRADO', notes: '', is_synced: true };
             const isRecorded = dailyStatus.attendance_records.some(r => r.student_id === student.id);
-
             return (
               <tr key={student.id}>
-                <td>{student.id}</td>
-                <td>{student.full_name}</td>
-                <td>{student.nickname}</td>
+                <td>{student.id}</td><td>{student.full_name}</td><td>{student.nickname}</td>
                 <td>
                   {(() => {
                     const record = dailyStatus.attendance_records.find(r => r.student_id === student.id);
-                    if (record) {
-                      return getDisplayableAttendanceInfo(record.status, record.points_earned, record.base_attendance_points);
-                    }
-                    // Si es un cambio local no sincronizado (aunque la lógica actual no lo permite mucho tiempo)
+                    if (record) return getDisplayableAttendanceInfo(record.status, record.points_earned, record.base_attendance_points);
                     if (currentStudentAttendance.status !== 'NO_REGISTRADO' && !currentStudentAttendance.is_synced) {
-                       // Para cambios locales, no tenemos los puntos exactos del backend aún, podríamos mostrar solo el texto
                        const statusText = STATUS_DISPLAY_MAP[currentStudentAttendance.status]?.text || currentStudentAttendance.status;
                        return `${statusText} (Pendiente de guardar)`;
                     }
@@ -603,25 +503,18 @@ const TeacherAttendancePage = () => {
                   })()}
                 </td>
                 <td>
-                  {isRecorded && currentStudentAttendance.status.startsWith('AUSENCIA') ? (
-                    <span style={{ color: 'red' }}>Ausente (Cierre Realizado)</span>
-                  ) : (
+                  {isRecorded && currentStudentAttendance.status.startsWith('AUSENCIA') ? (<span style={{ color: 'red' }}>Ausente (Cierre Realizado)</span>) : (
                     <button
                         onClick={() => handleProcessAttendanceClick(student)}
                         disabled={tardanzaModalOpen || isAttendanceEffectivelyClosed}
                     >
-                      {isRecorded ? 'Corregir Asistencia' : 'Marcar Asistencia'}
+                      {/* 11. Adaptar texto del botón de acción principal */}
+                      {isRecorded ? 'Corregir Asistencia' : (historicDateProp ? 'Registrar Estado' : 'Marcar Asistencia')}
                     </button>
                   )}
                 </td>
                 <td>
-                  <input
-                    type="text"
-                    value={currentStudentAttendance.notes}
-                    onChange={(e) => handleAttendanceChange(student.id, 'notes', e.target.value)}
-                    placeholder="Notas..."
-                    disabled={(isRecorded && currentStudentAttendance.status.startsWith('AUSENCIA')) || isAttendanceEffectivelyClosed}
-                  />
+                  <input type="text" value={currentStudentAttendance.notes} onChange={(e) => handleAttendanceChange(student.id, 'notes', e.target.value)} placeholder="Notas..." disabled={(isRecorded && currentStudentAttendance.status.startsWith('AUSENCIA')) || isAttendanceEffectivelyClosed} />
                 </td>
               </tr>
             );
@@ -629,21 +522,13 @@ const TeacherAttendancePage = () => {
         </tbody>
       </table>
 
-      <button
-        onClick={handleOpenCloseAttendanceModal}
-        disabled={isAttendanceEffectivelyClosed} // Corrected variable name
-        style={{marginTop: '20px'}}
-      >
-        {isAttendanceEffectivelyClosed ? 'Asistencia del Día Cerrada' : 'Realizar Cierre de Asistencia'}
+      {/* 12. Adaptar texto del botón de cierre de asistencia */}
+      <button onClick={handleOpenCloseAttendanceModal} disabled={isAttendanceEffectivelyClosed} style={{marginTop: '20px'}}>
+        {isAttendanceEffectivelyClosed ? `Asistencia del ${dateForOperations} Cerrada` : `Realizar Cierre de Asistencia (${dateForOperations})`}
       </button>
 
-      {/* Renderizar el modal de tardanza */}
       {renderTardanzaModal()}
-
-      {/* Renderizar el modal de cierre de asistencia */}
       {renderCloseAttendanceModal()}
-
-      {/* Los estilos del modal se moverán a un archivo CSS global o se definirán de otra manera si es necesario */}
     </div>
   );
 };


### PR DESCRIPTION
Se añade la funcionalidad "Ingresar Registro Pasado" para docentes.

Frontend:
- Nueva ruta y página `/docente/ingreso-historico` con selector de fecha.
- `TeacherAttendancePage` adaptada para operar con una fecha seleccionada (prop) o la fecha actual.
- UI ajustada para el contexto de fecha histórica (ej. bono deshabilitado).
- Todas las operaciones de asistencia ahora utilizan la fecha de contexto correcta.

Backend:
- No se requirieron cambios. Los endpoints existentes ya manejan un parámetro de fecha.

Esta funcionalidad permite a los docentes cargar la interfaz de asistencia para cualquier fecha pasada y registrar o modificar datos de asistencia correspondientes a esa fecha.