### PR TITLE
feat: Implementar ingreso de asistencia para fechas históricas

### DIFF
--- a/frontend/src/pages/TeacherHistoricAttendancePage.jsx
+++ b/frontend/src/pages/TeacherHistoricAttendancePage.jsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import TeacherAttendancePage from './TeacherAttendancePage';
+
+const TeacherHistoricAttendancePage = () => {
+  const [selectedDate, setSelectedDate] = useState('');
+  const [showAttendance, setShowAttendance] = useState(false);
+
+  const handleDateChange = (event) => {
+    setSelectedDate(event.target.value);
+    setShowAttendance(false);
+  };
+
+  const handleLoadAttendance = () => {
+    if (selectedDate) {
+      setShowAttendance(true);
+    } else {
+      alert('Por favor, seleccione una fecha.');
+    }
+  };
+
+  const getTodayDateString = () => {
+    const today = new Date();
+    const year = today.getFullYear();
+    const month = (today.getMonth() + 1).toString().padStart(2, '0');
+    const day = today.getDate().toString().padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  };
+
+  return (
+    <div>
+      <h2>Ingresar Registro Pasado de Asistencia</h2>
+      <Link to="/docente/dashboard">Volver al Panel</Link>
+      <div style={{ margin: '20px 0' }}>
+        <label htmlFor="historic-date">Seleccione una fecha:</label>
+        <input
+          type="date"
+          id="historic-date"
+          value={selectedDate}
+          onChange={handleDateChange}
+          max={getTodayDateString()}
+          style={{ marginLeft: '10px' }}
+        />
+        <button onClick={handleLoadAttendance} style={{ marginLeft: '10px' }} disabled={!selectedDate}>
+          Cargar Interfaz de Asistencia
+        </button>
+      </div>
+
+      {showAttendance && selectedDate && (
+        <div>
+          <hr />
+          <h3 style={{ fontWeight: 'bold', color: 'blue' }}>
+            Interfaz de Asistencia para la fecha: {selectedDate}
+          </h3>
+          <TeacherAttendancePage selectedDate={selectedDate} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TeacherHistoricAttendancePage;


### PR DESCRIPTION
Se añade la funcionalidad "Ingresar Registro Pasado" para docentes.

Frontend:
- Nueva ruta y página `/docente/ingreso-historico` con selector de fecha.
- `TeacherAttendancePage` adaptada para operar con una fecha seleccionada (prop) o la fecha actual.
- UI ajustada para el contexto de fecha histórica (ej. bono deshabilitado).
- Todas las operaciones de asistencia ahora utilizan la fecha de contexto correcta.

Backend:
- No se requirieron cambios. Los endpoints existentes ya manejan un parámetro de fecha.

Esta funcionalidad permite a los docentes cargar la interfaz de asistencia para cualquier fecha pasada y registrar o modificar datos de asistencia correspondientes a esa fecha.