### PR TITLE
feat: Implementar ingreso de asistencia para fechas históricas

### DIFF
--- a/frontend/src/pages/TeacherDashboardPage.jsx
+++ b/frontend/src/pages/TeacherDashboardPage.jsx
@@ -24,6 +24,7 @@ const TeacherDashboardPage = () => {
           <li><Link to="/docente/ranking">Ranking Mensual</Link></li>
           <li><Link to="/docente/lista-estudiantes">Lista de Estudiantes</Link></li>
           <li><Link to="/docente/database">Base de Datos Estudiantes</Link></li> {/* Nuevo enlace */}
+          <li><Link to="/docente/ingreso-historico">Ingresar Registro Pasado</Link></li> {/* Enlace a la nueva funcionalidad */}
           {/* <li><Link to="/docente/editar-registro">Editar registro</Link></li> (Definir qué es esto) */}
           {/* <li><Link to="/docente/icono-registro">Ícono de registro</Link></li> (Definir qué es esto) */}
           <li><button onClick={handleLogout}>Salir</button></li>


### PR DESCRIPTION
Se añade la funcionalidad "Ingresar Registro Pasado" para docentes, incluyendo el enlace de navegación en el panel del docente.

Frontend:
- Nueva ruta y página `/docente/ingreso-historico` con selector de fecha.
- `TeacherAttendancePage` adaptada para operar con una fecha seleccionada (prop) o la fecha actual.
- UI ajustada para el contexto de fecha histórica (ej. bono deshabilitado).
- Todas las operaciones de asistencia ahora utilizan la fecha de contexto correcta.
- Añadido enlace a "Ingresar Registro Pasado" en `TeacherDashboardPage`.

Backend:
- No se requirieron cambios. Los endpoints existentes ya manejan un parámetro de fecha.

Esta funcionalidad permite a los docentes cargar la interfaz de asistencia para cualquier fecha pasada y registrar o modificar datos de asistencia correspondientes a esa fecha.