### PR TITLE
refactor: Ajustar color del botón de registro para diferenciación

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,7 +8,7 @@
 
   --primary-color-teacher: #9D4EDD; /* Morado vibrante */
   --primary-color-student: #3498DB; /* Azul eléctrico/brillante */
-  --primary-color-register: #58A6FF; /* Un azul un poco más claro para diferenciar registro */
+  --primary-color-register: #16A085; /* Teal Oscuro para el botón de registro */
 
   --text-color-main: #E0E0E0;       /* Gris muy claro */
   --text-color-light: #FFFFFF;


### PR DESCRIPTION
Se actualiza el color del botón "Regístrate Aquí" en la página de inicio a un Teal Oscuro (#16A085).

Esto se logra modificando la variable CSS `--primary-color-register` en `index.css`.

El objetivo es diferenciar visualmente este botón de los botones de login de docente y estudiante, manteniendo la armonía general del nuevo tema oscuro.