### PR TITLE
fix: Corregir ruta de importación para ToggleSwitch en Dashboard

### DIFF
--- a/frontend/src/pages/TeacherDashboardPage.jsx
+++ b/frontend/src/pages/TeacherDashboardPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import axios from 'axios';
-import ToggleSwitch from '../../components/ToggleSwitch'; // Ajustar ruta si es necesario
+import ToggleSwitch from '../components/ToggleSwitch'; // Ruta Corregida
 
 // Ícono para el botón Salir
 const LogoutIcon = () => ( // Renombrado para claridad, era ArrowLeftOnRectangleIcon


### PR DESCRIPTION
Se corrige la ruta de importación del componente `ToggleSwitch` dentro de `TeacherDashboardPage.jsx` para resolver un error de compilación de Vite ("Failed to resolve import").

La ruta incorrecta era `../../components/ToggleSwitch` y ha sido corregida a `../components/ToggleSwitch`.

Este commit también consolida toda la implementación de la Fase 8: Interruptor de Habilitación de Inscripciones Públicas, que incluye:
- Cambios en el backend (BD, nuevas rutas de admin, modificación de ruta pública de registro, y nueva ruta pública para verificar estado).
- Creación del componente `ToggleSwitch` en el frontend y sus estilos.
- Integración del interruptor en el `TeacherDashboardPage` con lógica para obtener y actualizar el estado vía API.
- Modificación opcional de `PublicRegistrationPage` para reflejar el estado de las inscripciones.