### PR TITLE
fix: Corregir error 'useEffect is not defined' en PublicRegistrationPage

### DIFF
--- a/frontend/src/pages/PublicRegistrationPage.jsx
+++ b/frontend/src/pages/PublicRegistrationPage.jsx
@@ -1,6 +1,6 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react'; // useEffect añadido
 import axios from 'axios';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom'; // useNavigate no se usa, se puede quitar si no hay redirección
 
 const PublicRegistrationPage = () => {
   const initialFormData = {


### PR DESCRIPTION
Se corrige un `ReferenceError: useEffect is not defined` en `PublicRegistrationPage.jsx` al añadir `useEffect` a las importaciones de React.

Esta corrección permite que la página de registro público se renderice correctamente y, por lo tanto, que el botón/enlace "Regístrate Aquí" desde la página de inicio funcione como se esperaba.

La funcionalidad completa de la Fase 8 (Interruptor de Inscripciones Públicas y su efecto en la página de registro) ahora debería estar operativa.