### PR TITLE
feat: Implement user profile management for teachers and students

### DIFF
--- a/backend/init.sql
+++ b/backend/init.sql
@@ -4,12 +4,13 @@ CREATE TABLE students (
     id VARCHAR(10) PRIMARY KEY,
     full_name VARCHAR(255) NOT NULL,
     nickname VARCHAR(100),
-    password TEXT,
+    password_hash TEXT, -- Renombrado de password a password_hash
     is_active BOOLEAN DEFAULT true NOT NULL,
-    -- Nuevos campos Fase 7
+    photo_url VARCHAR(255), -- Nuevo campo para la foto de perfil
+    -- Nuevos campos Fase 7 (y ahora perfil)
     age INTEGER,
     birth_date DATE,
-    phone VARCHAR(20),
+    phone VARCHAR(20), -- Este será el "celular" del estudiante
     email VARCHAR(255) UNIQUE, -- Email debe ser único
     guardian_full_name TEXT,
     guardian_relationship VARCHAR(50),
@@ -21,14 +22,18 @@ CREATE TABLE students (
     emergency_contact_phone VARCHAR(20)
 );
 
--- Insertar estudiantes con contraseñas de ejemplo y algunos campos nuevos como NULL o vacíos
--- Para una prueba completa, se deberían llenar algunos de estos campos para algunos estudiantes.
-INSERT INTO students (id, full_name, nickname, password, is_active, age, birth_date, phone, email) VALUES
-('ET001', 'Adriano Rivera , Ana Liz', 'Ana', 'ET001pass', true, NULL, NULL, NULL, 'et001@example.com'),
-('ET002', 'Alarcón Lizarbe, Samantha Valentina', 'Samy', 'ET002pass', true, NULL, NULL, NULL, 'et002@example.com'),
-('ET003', 'Baltazar Bazan , María Fernanda', 'Fer', 'ET003pass', true, NULL, NULL, NULL, 'et003@example.com'),
--- ... (se omiten los demás para brevedad, pero se añadirían con NULLs o datos de ejemplo para los nuevos campos)
-('ET057', 'Moreno Arévalo, Génesis', 'Génesis', 'ET057pass', true, 17, '2007-05-10', '987654321', 'et057@example.com');
+-- Insertar estudiantes con contraseñas HASHEADAS de ejemplo.
+-- Las contraseñas originales (ej: 'ET001pass') deben ser reemplazadas por sus hashes.
+-- Ejemplo de hashes (reemplazar con hashes reales):
+-- 'ET001pass' -> '$2a$10$studentPassHashPlaceholder1'
+-- 'ET002pass' -> '$2a$10$studentPassHashPlaceholder2'
+-- etc.
+INSERT INTO students (id, full_name, nickname, password_hash, is_active, age, birth_date, phone, email, photo_url) VALUES
+('ET001', 'Adriano Rivera , Ana Liz', 'Ana', '$2a$10$studentPassHashPlaceholder1', true, NULL, NULL, NULL, 'et001@example.com', NULL),
+('ET002', 'Alarcón Lizarbe, Samantha Valentina', 'Samy', '$2a$10$studentPassHashPlaceholder2', true, NULL, NULL, NULL, 'et002@example.com', NULL),
+('ET003', 'Baltazar Bazan , María Fernanda', 'Fer', '$2a$10$studentPassHashPlaceholder3', true, NULL, NULL, NULL, 'et003@example.com', NULL),
+-- ... (se omiten los demás para brevedad, pero se añadirían con hashes y photo_url=NULL)
+('ET057', 'Moreno Arévalo, Génesis', 'Génesis', '$2a$10$studentPassHashPlaceholder57', true, 17, '2007-05-10', '987654321', 'et057@example.com', NULL);
 
 
 -- Tabla para registrar la asistencia diaria de los estudiantes
@@ -96,3 +101,25 @@ CREATE TABLE IF NOT EXISTS system_settings (
 INSERT INTO system_settings (setting_key, setting_value)
 VALUES ('public_registration_enabled', 'true')
 ON CONFLICT (setting_key) DO NOTHING;
+
+-- Tabla para Docentes
+DROP TABLE IF EXISTS teachers CASCADE;
+CREATE TABLE teachers (
+    id SERIAL PRIMARY KEY,
+    full_name VARCHAR(255) NOT NULL,
+    nickname VARCHAR(100),
+    email VARCHAR(255) UNIQUE NOT NULL,
+    cellphone_number VARCHAR(20),
+    password_hash VARCHAR(255) NOT NULL,
+    photo_url VARCHAR(255) -- Para la URL de la foto de perfil
+);
+
+-- Crear un índice en el email del docente para búsquedas rápidas
+CREATE UNIQUE INDEX IF NOT EXISTS idx_teachers_email ON teachers(email);
+
+-- Insertar datos iniciales del docente
+-- La contraseña '3ddv6e5N' debe ser hasheada antes de insertarla.
+-- Ejemplo de hash (reemplazar con el hash real): '$2a$10$exampleHashValueForTheTeacher123'
+INSERT INTO teachers (full_name, nickname, email, cellphone_number, password_hash, photo_url) VALUES
+('Luis Acuña', 'Lucho', 'luisacunach@gmail.com', '949179423', '$2a$10$exampleHashValueForTheTeacher123', NULL)
+ON CONFLICT (email) DO NOTHING;

--- a/backend/routes/teacherRoutes.js
+++ b/backend/routes/teacherRoutes.js
@@ -1,0 +1,130 @@
+const express = require('express');
+const pool = require('../config/db');
+const bcrypt = require('bcryptjs');
+const authMiddleware = require('../middleware/authMiddleware');
+
+const router = express.Router();
+
+// @route   GET /api/teachers/profile
+// @desc    Get current teacher's profile
+// @access  Private (Teacher)
+router.get('/profile', authMiddleware, async (req, res) => {
+  // Ensure only teachers can access this
+  if (req.user.role !== 'teacher') {
+    return res.status(403).json({ message: 'Acceso denegado. Solo para docentes.' });
+  }
+
+  try {
+    const result = await pool.query(
+      'SELECT id, full_name, nickname, email, cellphone_number, photo_url FROM teachers WHERE id = $1',
+      [req.user.id]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ message: 'Perfil de docente no encontrado.' });
+    }
+
+    res.json(result.rows[0]);
+  } catch (err) {
+    console.error('Error fetching teacher profile:', err);
+    res.status(500).json({ message: 'Error interno del servidor.' });
+  }
+});
+
+// @route   PUT /api/teachers/profile
+// @desc    Update current teacher's profile
+// @access  Private (Teacher)
+router.put('/profile', authMiddleware, async (req, res) => {
+  if (req.user.role !== 'teacher') {
+    return res.status(403).json({ message: 'Acceso denegado. Solo para docentes.' });
+  }
+
+  const { full_name, nickname, email, cellphone_number } = req.body;
+  const teacherId = req.user.id;
+
+  // Basic validation
+  if (!full_name || !email) {
+    return res.status(400).json({ message: 'Nombre completo y email son requeridos.' });
+  }
+
+  try {
+    // Check if email is being changed and if it's already taken by another user
+    if (email !== req.user.email) {
+      const emailCheck = await pool.query('SELECT id FROM teachers WHERE email = $1 AND id != $2', [email, teacherId]);
+      if (emailCheck.rows.length > 0) {
+        return res.status(400).json({ message: 'El email ya está en uso por otra cuenta.' });
+      }
+    }
+
+    const result = await pool.query(
+      `UPDATE teachers
+       SET full_name = $1, nickname = $2, email = $3, cellphone_number = $4
+       WHERE id = $5
+       RETURNING id, full_name, nickname, email, cellphone_number, photo_url`,
+      [full_name, nickname, email, cellphone_number, teacherId]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ message: 'Perfil de docente no encontrado para actualizar.' });
+    }
+
+    res.json({ message: 'Perfil actualizado exitosamente.', teacher: result.rows[0] });
+  } catch (err) {
+    console.error('Error updating teacher profile:', err);
+    // Catch unique constraint violation for email if not caught by the explicit check (race condition, etc.)
+    if (err.code === '23505' && err.constraint === 'teachers_email_key') {
+        return res.status(400).json({ message: 'El email ya está en uso.' });
+    }
+    res.status(500).json({ message: 'Error interno del servidor.' });
+  }
+});
+
+// @route   PUT /api/teachers/password
+// @desc    Change current teacher's password
+// @access  Private (Teacher)
+router.put('/password', authMiddleware, async (req, res) => {
+  if (req.user.role !== 'teacher') {
+    return res.status(403).json({ message: 'Acceso denegado. Solo para docentes.' });
+  }
+
+  const { current_password, new_password, confirm_new_password } = req.body;
+  const teacherId = req.user.id;
+
+  if (!current_password || !new_password || !confirm_new_password) {
+    return res.status(400).json({ message: 'Todos los campos de contraseña son requeridos.' });
+  }
+
+  if (new_password !== confirm_new_password) {
+    return res.status(400).json({ message: 'La nueva contraseña y su confirmación no coinciden.' });
+  }
+
+  if (new_password.length < 6) { // Example minimum length
+    return res.status(400).json({ message: 'La nueva contraseña debe tener al menos 6 caracteres.' });
+  }
+
+  try {
+    const userResult = await pool.query('SELECT password_hash FROM teachers WHERE id = $1', [teacherId]);
+    if (userResult.rows.length === 0) {
+      return res.status(404).json({ message: 'Usuario no encontrado.' });
+    }
+
+    const teacher = userResult.rows[0];
+    const isMatch = await bcrypt.compare(current_password, teacher.password_hash);
+
+    if (!isMatch) {
+      return res.status(400).json({ message: 'La contraseña actual es incorrecta.' });
+    }
+
+    const salt = await bcrypt.genSalt(10);
+    const newPasswordHash = await bcrypt.hash(new_password, salt);
+
+    await pool.query('UPDATE teachers SET password_hash = $1 WHERE id = $2', [newPasswordHash, teacherId]);
+
+    res.json({ message: 'Contraseña actualizada exitosamente.' });
+  } catch (err) {
+    console.error('Error changing teacher password:', err);
+    res.status(500).json({ message: 'Error interno del servidor.' });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -11,6 +11,7 @@ const studentRoutes = require('./routes/studentRoutes');
 const studentAdminRoutes = require('./routes/studentAdminRoutes');
 const publicRoutes = require('./routes/publicRoutes'); // Nuevas rutas públicas
 const adminSettingsRoutes = require('./routes/adminSettingsRoutes'); // <-- Importar nuevas rutas
+const teacherRoutes = require('./routes/teacherRoutes'); // <-- Importar rutas de docente
 
 // Importar Middleware (si es necesario globalmente o para rutas específicas aquí)
 const authMiddleware = require('./middleware/authMiddleware');
@@ -24,6 +25,7 @@ app.use(express.json()); // Para parsear JSON en las requests
 
 // Definición de Rutas
 app.use('/api/auth', authRoutes);
+app.use('/api/teachers', teacherRoutes); // Rutas para el perfil del docente (ya usan authMiddleware internamente)
 app.use('/api/attendance', authMiddleware, attendanceRoutes);
 app.use('/api/scores', authMiddleware, scoreRoutes);
 app.use('/api/reports', authMiddleware, reportRoutes);
@@ -36,14 +38,7 @@ app.use('/api/public', publicRoutes); // Rutas públicas (ej: /api/public/regist
 // y es más completa (permite filtrar por is_active).
 // El frontend deberá actualizarse para usar /api/admin/students?active=true para la lista principal.
 
-// Ejemplo de ruta protegida
-app.get('/api/teacher/profile', authMiddleware, (req, res) => {
-  // req.user es accesible aquí gracias al authMiddleware
-  res.json({
-    message: 'Este es un perfil de docente protegido.',
-    user: req.user
-  });
-});
+// El ejemplo de ruta protegida /api/teacher/profile se elimina ya que está cubierto por teacherRoutes.js
 
 
 // Iniciar servidor

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,9 +12,11 @@ import TeacherSummaryPage from './pages/TeacherSummaryPage';
 import TeacherRankingPage from './pages/TeacherRankingPage';
 import TeacherDatabasePage from './pages/TeacherDatabasePage';
 import TeacherHistoricAttendancePage from './pages/TeacherHistoricAttendancePage';
+import TeacherProfilePage from './pages/TeacherProfilePage'; // Import TeacherProfilePage
 import StudentLoginPage from './pages/StudentLoginPage';
 import StudentDashboardPage from './pages/StudentDashboardPage';
 import StudentScoresDetailPage from './pages/StudentScoresDetailPage';
+import StudentProfilePage from './pages/StudentProfilePage'; // Import StudentProfilePage
 import PublicRegistrationPage from './pages/PublicRegistrationPage';
 import ProtectedRoute from './components/ProtectedRoute';
 import WhatsAppButton from './components/WhatsAppButton';
@@ -81,11 +83,13 @@ function App() {
               <Route path="/docente/resumen" element={<TeacherSummaryPage />} />
               <Route path="/docente/ranking" element={<TeacherRankingPage />} />
               <Route path="/docente/ingreso-historico" element={<TeacherHistoricAttendancePage />} />
+              <Route path="/docente/mi-perfil" element={<TeacherProfilePage />} /> {/* Add route for TeacherProfilePage */}
             </Route>
             <Route path="/estudiante/login" element={<StudentLoginPage />} />
             <Route element={<ProtectedRoute tokenType="studentToken" redirectTo="/estudiante/login" />}>
               <Route path="/estudiante/dashboard" element={<StudentDashboardPage />} />
               <Route path="/estudiante/mis-puntajes" element={<StudentScoresDetailPage />} />
+              <Route path="/estudiante/mi-perfil" element={<StudentProfilePage />} /> {/* Add route for StudentProfilePage */}
             </Route>
             <Route path="*" element={
               <div className="centered-form-page" style={{textAlign: 'center'}}>

--- a/frontend/src/pages/StudentDashboardPage.jsx
+++ b/frontend/src/pages/StudentDashboardPage.jsx
@@ -5,6 +5,7 @@ import { useNavigate, Link } from 'react-router-dom';
 // Iconos SVG
 const LogoutIcon = () => <svg className="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="16" height="16"><path fillRule="evenodd" d="M3 3.25A2.25 2.25 0 015.25 1h5.5A2.25 2.25 0 0113 3.25V4.5a.75.75 0 01-1.5 0V3.25a.75.75 0 00-.75-.75h-5.5a.75.75 0 00-.75.75v13.5a.75.75 0 00.75.75h5.5a.75.75 0 00.75-.75v-1.25a.75.75 0 011.5 0V16.75a2.25 2.25 0 01-2.25 2.25h-5.5A2.25 2.25 0 013 16.75V3.25zm10.97 9.22a.75.75 0 001.06-1.06l-1.72-1.72h3.44a.75.75 0 000-1.5H12.81l1.72-1.72a.75.75 0 00-1.06-1.06l-3 3a.75.75 0 000 1.06l3 3z" clipRule="evenodd" /></svg>;
 const ScoresIcon = () => <svg className="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24" height="24"><path fillRule="evenodd" d="M4.5 3.75A.75.75 0 015.25 3h13.5a.75.75 0 01.75.75v16.5a.75.75 0 01-.75.75H5.25a.75.75 0 01-.75-.75V3.75zM9 6a.75.75 0 01.75.75v.008c0 .414.336.75.75.75h3a.75.75 0 00.75-.75V6.75A.75.75 0 0115 6h.75a.75.75 0 01.75.75v3.75a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75V6.75A.75.75 0 019 6zm0 6.75a.75.75 0 01.75.75v.008c0 .414.336.75.75.75h3a.75.75 0 00.75-.75V13.5a.75.75 0 01.75-.75H15A.75.75 0 0115.75 12v3.75a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75V13.5a.75.75 0 01.75-.75z" clipRule="evenodd" /></svg>;
+const UserCircleIcon = () => <svg className="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24" height="24"><path fillRule="evenodd" d="M18.685 19.097A9.723 9.723 0 0021.75 12c0-5.385-4.365-9.75-9.75-9.75S2.25 6.615 2.25 12a9.723 9.723 0 003.065 7.097A9.716 9.716 0 0012 21.75a9.716 9.716 0 006.685-2.653zm-12.54-1.285A7.486 7.486 0 0112 15a7.486 7.486 0 015.855 2.812A8.224 8.224 0 0112 20.25a8.224 8.224 0 01-5.855-2.438zM15.75 9a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" clipRule="evenodd" /></svg>;
 
 
 const StudentDashboardPage = () => {
@@ -132,6 +133,9 @@ const StudentDashboardPage = () => {
       <div className="dashboard-actions-grid" style={{marginTop: '1.5rem'}}>
         <Link to="/estudiante/mis-puntajes" className="dashboard-action-card">
           <ScoresIcon /> Ver Mis Puntajes Detallados
+        </Link>
+        <Link to="/estudiante/mi-perfil" className="dashboard-action-card">
+          <UserCircleIcon /> Mi Perfil
         </Link>
       </div>
        <div style={{textAlign: 'center', marginTop: '2.5rem'}}>

--- a/frontend/src/pages/StudentProfilePage.jsx
+++ b/frontend/src/pages/StudentProfilePage.jsx
@@ -1,0 +1,406 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import axios from 'axios';
+
+// Re-using styles from TeacherProfilePage for consistency, or define separately
+const styles = {
+  pageContainer: {
+    maxWidth: '800px', // Slightly wider for potentially more fields
+    margin: '2rem auto',
+    padding: '2rem',
+    border: '1px solid #ddd',
+    borderRadius: '8px',
+    backgroundColor: '#f9f9f9',
+  },
+  formSection: {
+    marginBottom: '2rem',
+    padding: '1.5rem',
+    border: '1px solid #eee',
+    borderRadius: '8px',
+    backgroundColor: '#fff',
+  },
+  formGroup: {
+    marginBottom: '1rem',
+  },
+  label: {
+    display: 'block',
+    marginBottom: '0.5rem',
+    fontWeight: 'bold',
+  },
+  input: {
+    width: '100%',
+    padding: '0.75rem',
+    border: '1px solid #ccc',
+    borderRadius: '4px',
+    boxSizing: 'border-box',
+  },
+  textarea: {
+    width: '100%',
+    padding: '0.75rem',
+    border: '1px solid #ccc',
+    borderRadius: '4px',
+    boxSizing: 'border-box',
+    minHeight: '80px',
+  },
+  button: {
+    padding: '0.75rem 1.5rem',
+    backgroundColor: 'var(--primary-color-student)', // Student theme color
+    color: 'white',
+    border: 'none',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    fontSize: '1rem',
+  },
+  buttonDisabled: {
+    backgroundColor: '#ccc',
+  },
+  errorMessage: {
+    color: 'red',
+    marginBottom: '1rem',
+  },
+  successMessage: {
+    color: 'green',
+    marginBottom: '1rem',
+  },
+  photoSection: {
+    textAlign: 'center',
+    marginBottom: '1.5rem',
+  },
+  profilePhoto: {
+    width: '128px',
+    height: '128px',
+    borderRadius: '50%',
+    objectFit: 'cover',
+    border: '3px solid #ccc',
+    backgroundColor: '#e0e0e0'
+  },
+  gridContainer: { // For guardian, medical, emergency sections
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gap: '1rem'
+  }
+};
+
+
+const StudentProfilePage = () => {
+  const navigate = useNavigate();
+  const API_BASE_URL = 'http://localhost:3001/api/student'; // Corrected API base
+  const getToken = useCallback(() => localStorage.getItem('studentToken'), []);
+
+  const initialProfileData = {
+    full_name: '', // Display only, not editable by student
+    nickname: '',
+    email: '',
+    phone: '', // Celular
+    photo_url: '',
+    age: '', // Display only
+    birth_date: '', // Display only
+    guardian_full_name: '',
+    guardian_relationship: '',
+    guardian_phone: '',
+    guardian_email: '',
+    medical_conditions: '',
+    // comments: '', // Usually not editable by student
+    emergency_contact_name: '',
+    emergency_contact_phone: ''
+  };
+
+  const [profile, setProfile] = useState(initialProfileData);
+  const [initialFetchedProfile, setInitialFetchedProfile] = useState(initialProfileData);
+
+
+  const [passwordData, setPasswordData] = useState({
+    current_password: '',
+    new_password: '',
+    confirm_new_password: ''
+  });
+
+  const [loadingProfile, setLoadingProfile] = useState(true);
+  const [profileError, setProfileError] = useState('');
+  const [profileSuccess, setProfileSuccess] = useState('');
+
+  const [loadingPassword, setLoadingPassword] = useState(false);
+  const [passwordError, setPasswordError] = useState('');
+  const [passwordSuccess, setPasswordSuccess] = useState('');
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      setLoadingProfile(true);
+      setProfileError('');
+      try {
+        const token = getToken();
+        if (!token) {
+          navigate('/estudiante/login');
+          return;
+        }
+        // Corrected endpoint to /profile
+        const response = await axios.get(`${API_BASE_URL}/profile`, {
+          headers: { 'x-auth-token': token }
+        });
+        // Ensure all fields in initialProfileData are present in response or set to default
+        const fetchedData = { ...initialProfileData, ...response.data };
+        setProfile(fetchedData);
+        setInitialFetchedProfile(fetchedData); // Store initial fetched data
+      } catch (err) {
+        console.error("Error fetching student profile:", err);
+        setProfileError(err.response?.data?.message || 'No se pudo cargar el perfil.');
+        if (err.response?.status === 401 || err.response?.status === 403) {
+          navigate('/estudiante/login');
+        }
+      } finally {
+        setLoadingProfile(false);
+      }
+    };
+    fetchProfile();
+  }, [getToken, navigate, API_BASE_URL]);
+
+  const handleProfileChange = (e) => {
+    setProfile({ ...profile, [e.target.name]: e.target.value });
+    setProfileSuccess('');
+    setProfileError('');
+  };
+
+  const handlePasswordChange = (e) => {
+    setPasswordData({ ...passwordData, [e.target.name]: e.target.value });
+    setPasswordSuccess('');
+    setPasswordError('');
+  };
+
+  const handleProfileSubmit = async (e) => {
+    e.preventDefault();
+    setLoadingProfile(true);
+    setProfileError('');
+    setProfileSuccess('');
+
+    // Client-side validation (basic examples)
+    if (profile.email && !/\S+@\S+\.\S+/.test(profile.email)) {
+        setProfileError('Por favor, introduce un email válido.');
+        setLoadingProfile(false);
+        return;
+    }
+    if (profile.phone && !/^\d{9,15}$/.test(profile.phone)) {
+        setProfileError('El número de celular debe tener entre 9 y 15 dígitos.');
+        setLoadingProfile(false);
+        return;
+    }
+    if (profile.guardian_phone && profile.guardian_phone.trim() !== '' && !/^\d{9,15}$/.test(profile.guardian_phone)) {
+      setProfileError('El teléfono del apoderado debe tener entre 9 y 15 dígitos.');
+      setLoadingProfile(false);
+      return;
+    }
+    if (profile.emergency_contact_phone && profile.emergency_contact_phone.trim() !== '' && !/^\d{9,15}$/.test(profile.emergency_contact_phone)) {
+      setProfileError('El teléfono de emergencia debe tener entre 9 y 15 dígitos.');
+      setLoadingProfile(false);
+      return;
+    }
+    if (profile.guardian_email && profile.guardian_email.trim() !== '' && !/\S+@\S+\.\S+/.test(profile.guardian_email)) {
+        setProfileError('Por favor, introduce un email de apoderado válido.');
+        setLoadingProfile(false);
+        return;
+    }
+
+    // Only send editable fields
+    const {
+        nickname, email, phone,
+        guardian_full_name, guardian_relationship, guardian_phone, guardian_email,
+        medical_conditions,
+        emergency_contact_name, emergency_contact_phone
+    } = profile;
+
+    const updatePayload = {
+        nickname, email, phone,
+        guardian_full_name, guardian_relationship, guardian_phone, guardian_email,
+        medical_conditions,
+        emergency_contact_name, emergency_contact_phone
+    };
+
+
+    try {
+      const token = getToken();
+      // Corrected endpoint to /profile
+      const response = await axios.put(`${API_BASE_URL}/profile`, updatePayload, {
+        headers: { 'x-auth-token': token }
+      });
+      setProfileSuccess(response.data.message || 'Perfil actualizado exitosamente.');
+      // Update profile with the response, which should include all fields
+      const updatedData = { ...initialProfileData, ...response.data.student };
+      setProfile(updatedData);
+      setInitialFetchedProfile(updatedData); // Update initial fetched profile
+    } catch (err) {
+      console.error("Error updating student profile:", err);
+      setProfileError(err.response?.data?.message || 'Error al actualizar el perfil.');
+    } finally {
+      setLoadingProfile(false);
+    }
+  };
+
+  const handlePasswordSubmit = async (e) => {
+    e.preventDefault();
+    setLoadingPassword(true);
+    setPasswordError('');
+    setPasswordSuccess('');
+
+    if (passwordData.new_password !== passwordData.confirm_new_password) {
+      setPasswordError('La nueva contraseña y su confirmación no coinciden.');
+      setLoadingPassword(false);
+      return;
+    }
+     if (passwordData.new_password.length < 6) {
+      setPasswordError('La nueva contraseña debe tener al menos 6 caracteres.');
+      setLoadingPassword(false);
+      return;
+    }
+
+    try {
+      const token = getToken();
+      // Corrected endpoint to /password
+      const response = await axios.put(`${API_BASE_URL}/password`, passwordData, {
+        headers: { 'x-auth-token': token }
+      });
+      setPasswordSuccess(response.data.message || 'Contraseña actualizada exitosamente.');
+      setPasswordData({ current_password: '', new_password: '', confirm_new_password: '' });
+    } catch (err) {
+      console.error("Error updating student password:", err);
+      setPasswordError(err.response?.data?.message || 'Error al cambiar la contraseña.');
+    } finally {
+      setLoadingPassword(false);
+    }
+  };
+
+  const profileHasChanged = JSON.stringify(profile) !== JSON.stringify(initialFetchedProfile);
+
+  if (loadingProfile && !profile.id && !profile.full_name) { // Show loading only on initial full fetch
+    return <div style={styles.pageContainer}><p>Cargando perfil...</p></div>;
+  }
+
+  return (
+    <div style={styles.pageContainer}>
+      <h2 style={{ textAlign: 'center', marginBottom: '1rem' }}>
+        Mi Perfil de Estudiante
+      </h2>
+      <p style={{textAlign: 'center', marginBottom: '2rem', fontSize: '1.2rem'}}>
+        ¡Hola, {profile.nickname || profile.full_name || 'Estudiante'}!
+      </p>
+
+      <div style={styles.photoSection}>
+        <img
+          src={profile.photo_url || `https://ui-avatars.com/api/?name=${encodeURIComponent(profile.full_name || 'N A')}&background=4A4A7F&color=E0E0E0&size=128&font-size=0.5&bold=true`}
+          alt="Foto de perfil"
+          style={styles.profilePhoto}
+        />
+        <p style={{marginTop: '0.5rem', fontSize: '0.9em', color: '#666'}}>
+          (Funcionalidad para cambiar foto próximamente)
+        </p>
+      </div>
+
+      {/* Edit Profile Form */}
+      <div style={styles.formSection}>
+        <h3>Editar Información Personal y de Contacto</h3>
+        {profileError && <p style={styles.errorMessage}>{profileError}</p>}
+        {profileSuccess && <p style={styles.successMessage}>{profileSuccess}</p>}
+        <form onSubmit={handleProfileSubmit}>
+          {/* Non-editable fields for display */}
+          <div style={styles.formGroup}>
+            <label style={styles.label}>Nombre Completo (No editable):</label>
+            <input type="text" value={profile.full_name || ''} style={{...styles.input, backgroundColor: '#f0f0f0'}} readOnly />
+          </div>
+           <div style={styles.gridContainer}>
+            <div style={styles.formGroup}>
+                <label style={styles.label}>ID Estudiante (No editable):</label>
+                <input type="text" value={profile.id || ''} style={{...styles.input, backgroundColor: '#f0f0f0'}} readOnly />
+            </div>
+            <div style={styles.formGroup}>
+                <label style={styles.label}>Edad (No editable):</label>
+                <input type="text" value={profile.age || ''} style={{...styles.input, backgroundColor: '#f0f0f0'}} readOnly />
+            </div>
+          </div>
+
+
+          <div style={styles.formGroup}>
+            <label htmlFor="nickname" style={styles.label}>Sobrenombre (Nickname):</label>
+            <input type="text" id="nickname" name="nickname" value={profile.nickname || ''} onChange={handleProfileChange} style={styles.input} />
+          </div>
+          <div style={styles.gridContainer}>
+            <div style={styles.formGroup}>
+              <label htmlFor="email" style={styles.label}>Correo Electrónico:</label>
+              <input type="email" id="email" name="email" value={profile.email || ''} onChange={handleProfileChange} style={styles.input} required />
+            </div>
+            <div style={styles.formGroup}>
+              <label htmlFor="phone" style={styles.label}>Celular:</label>
+              <input type="tel" id="phone" name="phone" value={profile.phone || ''} onChange={handleProfileChange} style={styles.input} pattern="\d{9,15}" title="Debe ser un número de 9 a 15 dígitos."/>
+            </div>
+          </div>
+
+          <h4 style={{marginTop: '2rem', marginBottom: '1rem'}}>Datos del Apoderado</h4>
+          <div style={styles.gridContainer}>
+            <div style={styles.formGroup}>
+              <label htmlFor="guardian_full_name" style={styles.label}>Nombre Completo del Apoderado:</label>
+              <input type="text" id="guardian_full_name" name="guardian_full_name" value={profile.guardian_full_name || ''} onChange={handleProfileChange} style={styles.input} />
+            </div>
+            <div style={styles.formGroup}>
+              <label htmlFor="guardian_relationship" style={styles.label}>Relación/Parentesco:</label>
+              <input type="text" id="guardian_relationship" name="guardian_relationship" value={profile.guardian_relationship || ''} onChange={handleProfileChange} style={styles.input} />
+            </div>
+            <div style={styles.formGroup}>
+              <label htmlFor="guardian_phone" style={styles.label}>Teléfono del Apoderado:</label>
+              <input type="tel" id="guardian_phone" name="guardian_phone" value={profile.guardian_phone || ''} onChange={handleProfileChange} style={styles.input} pattern="\d{9,15}" title="Debe ser un número de 9 a 15 dígitos."/>
+            </div>
+            <div style={styles.formGroup}>
+              <label htmlFor="guardian_email" style={styles.label}>Email del Apoderado:</label>
+              <input type="email" id="guardian_email" name="guardian_email" value={profile.guardian_email || ''} onChange={handleProfileChange} style={styles.input} />
+            </div>
+          </div>
+
+          <h4 style={{marginTop: '2rem', marginBottom: '1rem'}}>Datos Médicos y de Emergencia</h4>
+          <div style={styles.formGroup}>
+            <label htmlFor="medical_conditions" style={styles.label}>Condiciones Médicas Relevantes:</label>
+            <textarea id="medical_conditions" name="medical_conditions" value={profile.medical_conditions || ''} onChange={handleProfileChange} style={styles.textarea}></textarea>
+          </div>
+          <div style={styles.gridContainer}>
+            <div style={styles.formGroup}>
+              <label htmlFor="emergency_contact_name" style={styles.label}>Nombre Contacto de Emergencia:</label>
+              <input type="text" id="emergency_contact_name" name="emergency_contact_name" value={profile.emergency_contact_name || ''} onChange={handleProfileChange} style={styles.input} />
+            </div>
+            <div style={styles.formGroup}>
+              <label htmlFor="emergency_contact_phone" style={styles.label}>Teléfono Contacto de Emergencia:</label>
+              <input type="tel" id="emergency_contact_phone" name="emergency_contact_phone" value={profile.emergency_contact_phone || ''} onChange={handleProfileChange} style={styles.input} pattern="\d{9,15}" title="Debe ser un número de 9 a 15 dígitos."/>
+            </div>
+          </div>
+
+          <button type="submit" style={{...styles.button, ...( (loadingProfile || !profileHasChanged) && styles.buttonDisabled)}} disabled={loadingProfile || !profileHasChanged}>
+            {loadingProfile ? 'Guardando...' : 'Guardar Cambios de Perfil'}
+          </button>
+        </form>
+      </div>
+
+      {/* Change Password Form */}
+      <div style={styles.formSection}>
+        <h3>Cambiar Contraseña</h3>
+        {passwordError && <p style={styles.errorMessage}>{passwordError}</p>}
+        {passwordSuccess && <p style={styles.successMessage}>{passwordSuccess}</p>}
+        <form onSubmit={handlePasswordSubmit}>
+           <div style={styles.formGroup}>
+            <label htmlFor="current_password_student" style={styles.label}>Contraseña Actual:</label> {/* Changed id to avoid conflict if TeacherProfilePage CSS is global */}
+            <input type="password" id="current_password_student" name="current_password" value={passwordData.current_password} onChange={handlePasswordChange} style={styles.input} required />
+          </div>
+          <div style={styles.formGroup}>
+            <label htmlFor="new_password_student" style={styles.label}>Nueva Contraseña:</label>
+            <input type="password" id="new_password_student" name="new_password" value={passwordData.new_password} onChange={handlePasswordChange} style={styles.input} required minLength="6"/>
+          </div>
+          <div style={styles.formGroup}>
+            <label htmlFor="confirm_new_password_student" style={styles.label}>Confirmar Nueva Contraseña:</label>
+            <input type="password" id="confirm_new_password_student" name="confirm_new_password" value={passwordData.confirm_new_password} onChange={handlePasswordChange} style={styles.input} required minLength="6"/>
+          </div>
+          <button type="submit" style={{...styles.button, ...(loadingPassword && styles.buttonDisabled)}} disabled={loadingPassword}>
+            {loadingPassword ? 'Cambiando...' : 'Cambiar Contraseña'}
+          </button>
+        </form>
+      </div>
+      <div style={{ textAlign: 'center', marginTop: '2rem' }}>
+        <Link to="/estudiante/dashboard" className="secondary-link">Volver al Panel</Link>
+      </div>
+    </div>
+  );
+};
+
+export default StudentProfilePage;

--- a/frontend/src/pages/TeacherDashboardPage.jsx
+++ b/frontend/src/pages/TeacherDashboardPage.jsx
@@ -104,8 +104,7 @@ const TeacherDashboardPage = () => {
         <Link to="/docente/ranking" className="dashboard-action-card">Ranking Mensual</Link>
         <Link to="/docente/lista-estudiantes" className="dashboard-action-card">Lista de Estudiantes</Link>
         <Link to="/docente/database" className="dashboard-action-card">Base de Datos Estudiantes</Link>
-        {/* Futuro: Link a Mi Perfil Docente */}
-        {/* <Link to="/docente/mi-perfil" className="dashboard-action-card">Mi Perfil</Link> */}
+        <Link to="/docente/mi-perfil" className="dashboard-action-card">Mi Perfil</Link>
       </div>
 
       <div style={{ textAlign: 'center', marginTop: '2.5rem', marginBottom: '1rem' }}>

--- a/frontend/src/pages/TeacherProfilePage.jsx
+++ b/frontend/src/pages/TeacherProfilePage.jsx
@@ -1,0 +1,360 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import axios from 'axios';
+
+// Basic styling (can be moved to App.css or a dedicated CSS file)
+const styles = {
+  pageContainer: {
+    maxWidth: '700px',
+    margin: '2rem auto',
+    padding: '2rem',
+    border: '1px solid #ddd',
+    borderRadius: '8px',
+    backgroundColor: '#f9f9f9',
+  },
+  formSection: {
+    marginBottom: '2rem',
+    padding: '1.5rem',
+    border: '1px solid #eee',
+    borderRadius: '8px',
+    backgroundColor: '#fff',
+  },
+  formGroup: {
+    marginBottom: '1rem',
+  },
+  label: {
+    display: 'block',
+    marginBottom: '0.5rem',
+    fontWeight: 'bold',
+  },
+  input: {
+    width: '100%',
+    padding: '0.75rem',
+    border: '1px solid #ccc',
+    borderRadius: '4px',
+    boxSizing: 'border-box',
+  },
+  button: {
+    padding: '0.75rem 1.5rem',
+    backgroundColor: 'var(--primary-color)',
+    color: 'white',
+    border: 'none',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    fontSize: '1rem',
+  },
+  buttonDisabled: {
+    backgroundColor: '#ccc',
+  },
+  errorMessage: {
+    color: 'red',
+    marginBottom: '1rem',
+  },
+  successMessage: {
+    color: 'green',
+    marginBottom: '1rem',
+  },
+  photoSection: {
+    textAlign: 'center',
+    marginBottom: '1.5rem',
+  },
+  profilePhoto: {
+    width: '128px',
+    height: '128px',
+    borderRadius: '50%',
+    objectFit: 'cover',
+    border: '3px solid #ccc',
+    backgroundColor: '#e0e0e0'
+  }
+};
+
+const TeacherProfilePage = () => {
+  const navigate = useNavigate();
+  const API_BASE_URL = 'http://localhost:3001/api/teachers';
+  const getToken = useCallback(() => localStorage.getItem('teacherToken'), []);
+
+  // Profile data state
+  const [profile, setProfile] = useState({
+    full_name: '',
+    nickname: '',
+    email: '',
+    cellphone_number: '',
+    photo_url: ''
+  });
+  const [initialProfile, setInitialProfile] = useState({}); // To track changes
+
+  // Password change state
+  const [passwordData, setPasswordData] = useState({
+    current_password: '',
+    new_password: '',
+    confirm_new_password: ''
+  });
+
+  // Loading and error/success states
+  const [loadingProfile, setLoadingProfile] = useState(true);
+  const [profileError, setProfileError] = useState('');
+  const [profileSuccess, setProfileSuccess] = useState('');
+
+  const [loadingPassword, setLoadingPassword] = useState(false);
+  const [passwordError, setPasswordError] = useState('');
+  const [passwordSuccess, setPasswordSuccess] = useState('');
+
+  // Fetch profile data on component mount
+  useEffect(() => {
+    const fetchProfile = async () => {
+      setLoadingProfile(true);
+      setProfileError('');
+      try {
+        const token = getToken();
+        if (!token) {
+          navigate('/docente/login');
+          return;
+        }
+        const response = await axios.get(`${API_BASE_URL}/profile`, {
+          headers: { 'x-auth-token': token }
+        });
+        setProfile(response.data);
+        setInitialProfile(response.data); // Store initial data
+      } catch (err) {
+        console.error("Error fetching teacher profile:", err);
+        setProfileError(err.response?.data?.message || 'No se pudo cargar el perfil.');
+        if (err.response?.status === 401 || err.response?.status === 403) {
+          navigate('/docente/login');
+        }
+      } finally {
+        setLoadingProfile(false);
+      }
+    };
+    fetchProfile();
+  }, [getToken, navigate, API_BASE_URL]);
+
+  const handleProfileChange = (e) => {
+    setProfile({ ...profile, [e.target.name]: e.target.value });
+    setProfileSuccess(''); // Clear success message on change
+    setProfileError(''); // Clear error message on change
+  };
+
+  const handlePasswordChange = (e) => {
+    setPasswordData({ ...passwordData, [e.target.name]: e.target.value });
+    setPasswordSuccess('');
+    setPasswordError('');
+  };
+
+  const handleProfileSubmit = async (e) => {
+    e.preventDefault();
+    setLoadingProfile(true);
+    setProfileError('');
+    setProfileSuccess('');
+
+    // Basic client-side validation
+    if (!profile.full_name || !profile.email) {
+        setProfileError('Nombre completo y email son requeridos.');
+        setLoadingProfile(false);
+        return;
+    }
+    if (profile.email && !/\S+@\S+\.\S+/.test(profile.email)) {
+        setProfileError('Por favor, introduce un email válido.');
+        setLoadingProfile(false);
+        return;
+    }
+     if (profile.cellphone_number && !/^\d{9,15}$/.test(profile.cellphone_number)) {
+        setProfileError('El número de celular debe tener entre 9 y 15 dígitos.');
+        setLoadingProfile(false);
+        return;
+    }
+
+
+    try {
+      const token = getToken();
+      const response = await axios.put(`${API_BASE_URL}/profile`, profile, {
+        headers: { 'x-auth-token': token }
+      });
+      setProfileSuccess(response.data.message || 'Perfil actualizado exitosamente.');
+      setProfile(response.data.teacher); // Update profile with potentially new data from backend (e.g., if backend modifies something)
+      setInitialProfile(response.data.teacher); // Update initial profile to new state
+    } catch (err) {
+      console.error("Error updating profile:", err);
+      setProfileError(err.response?.data?.message || 'Error al actualizar el perfil.');
+    } finally {
+      setLoadingProfile(false);
+    }
+  };
+
+  const handlePasswordSubmit = async (e) => {
+    e.preventDefault();
+    setLoadingPassword(true);
+    setPasswordError('');
+    setPasswordSuccess('');
+
+    if (passwordData.new_password !== passwordData.confirm_new_password) {
+      setPasswordError('La nueva contraseña y su confirmación no coinciden.');
+      setLoadingPassword(false);
+      return;
+    }
+    if (passwordData.new_password.length < 6) {
+      setPasswordError('La nueva contraseña debe tener al menos 6 caracteres.');
+      setLoadingPassword(false);
+      return;
+    }
+
+    try {
+      const token = getToken();
+      const response = await axios.put(`${API_BASE_URL}/password`, passwordData, {
+        headers: { 'x-auth-token': token }
+      });
+      setPasswordSuccess(response.data.message || 'Contraseña actualizada exitosamente.');
+      setPasswordData({ current_password: '', new_password: '', confirm_new_password: '' }); // Clear fields
+    } catch (err) {
+      console.error("Error updating password:", err);
+      setPasswordError(err.response?.data?.message || 'Error al cambiar la contraseña.');
+    } finally {
+      setLoadingPassword(false);
+    }
+  };
+
+  // Check if profile form has changes
+  const profileHasChanged = JSON.stringify(profile) !== JSON.stringify(initialProfile);
+
+  if (loadingProfile && !profile.id) { // Show loading only on initial fetch
+    return <div style={styles.pageContainer}><p>Cargando perfil...</p></div>;
+  }
+
+  return (
+    <div style={styles.pageContainer}>
+      <h2 style={{ textAlign: 'center', marginBottom: '2rem' }}>
+        Mi Perfil - Hola, {profile.nickname || profile.full_name || 'Docente'}
+      </h2>
+
+      {/* Profile Photo Section - Placeholder */}
+      <div style={styles.photoSection}>
+        <img
+          src={profile.photo_url || `https://ui-avatars.com/api/?name=${encodeURIComponent(profile.full_name || 'N A')}&background=2A2A3E&color=E0E0E0&size=128&font-size=0.5&bold=true`}
+          alt="Foto de perfil"
+          style={styles.profilePhoto}
+        />
+        <p style={{marginTop: '0.5rem', fontSize: '0.9em', color: '#666'}}>
+          (Funcionalidad para cambiar foto próximamente)
+        </p>
+      </div>
+
+      {/* Edit Profile Form */}
+      <div style={styles.formSection}>
+        <h3>Editar Información Básica</h3>
+        {profileError && <p style={styles.errorMessage}>{profileError}</p>}
+        {profileSuccess && <p style={styles.successMessage}>{profileSuccess}</p>}
+        <form onSubmit={handleProfileSubmit}>
+          <div style={styles.formGroup}>
+            <label htmlFor="full_name" style={styles.label}>Nombres Completos:</label>
+            <input
+              type="text"
+              id="full_name"
+              name="full_name"
+              value={profile.full_name}
+              onChange={handleProfileChange}
+              style={styles.input}
+              required
+            />
+          </div>
+          <div style={styles.formGroup}>
+            <label htmlFor="nickname" style={styles.label}>Sobrenombre (Nickname):</label>
+            <input
+              type="text"
+              id="nickname"
+              name="nickname"
+              value={profile.nickname}
+              onChange={handleProfileChange}
+              style={styles.input}
+            />
+          </div>
+          <div style={styles.formGroup}>
+            <label htmlFor="email" style={styles.label}>Correo Electrónico:</label>
+            <input
+              type="email"
+              id="email"
+              name="email"
+              value={profile.email}
+              onChange={handleProfileChange}
+              style={styles.input}
+              required
+            />
+          </div>
+          <div style={styles.formGroup}>
+            <label htmlFor="cellphone_number" style={styles.label}>Número de Celular:</label>
+            <input
+              type="tel"
+              id="cellphone_number"
+              name="cellphone_number"
+              value={profile.cellphone_number}
+              onChange={handleProfileChange}
+              style={styles.input}
+              pattern="\d{9,15}"
+              title="Debe ser un número de 9 a 15 dígitos."
+            />
+          </div>
+          <button
+            type="submit"
+            style={{...styles.button, ...( (loadingProfile || !profileHasChanged) && styles.buttonDisabled)}}
+            disabled={loadingProfile || !profileHasChanged}
+          >
+            {loadingProfile ? 'Guardando...' : 'Guardar Cambios de Perfil'}
+          </button>
+        </form>
+      </div>
+
+      {/* Change Password Form */}
+      <div style={styles.formSection}>
+        <h3>Cambiar Contraseña</h3>
+        {passwordError && <p style={styles.errorMessage}>{passwordError}</p>}
+        {passwordSuccess && <p style={styles.successMessage}>{passwordSuccess}</p>}
+        <form onSubmit={handlePasswordSubmit}>
+          <div style={styles.formGroup}>
+            <label htmlFor="current_password" style={styles.label}>Contraseña Actual:</label>
+            <input
+              type="password"
+              id="current_password"
+              name="current_password"
+              value={passwordData.current_password}
+              onChange={handlePasswordChange}
+              style={styles.input}
+              required
+            />
+          </div>
+          <div style={styles.formGroup}>
+            <label htmlFor="new_password" style={styles.label}>Nueva Contraseña:</label>
+            <input
+              type="password"
+              id="new_password"
+              name="new_password"
+              value={passwordData.new_password}
+              onChange={handlePasswordChange}
+              style={styles.input}
+              required
+              minLength="6"
+            />
+          </div>
+          <div style={styles.formGroup}>
+            <label htmlFor="confirm_new_password" style={styles.label}>Confirmar Nueva Contraseña:</label>
+            <input
+              type="password"
+              id="confirm_new_password"
+              name="confirm_new_password"
+              value={passwordData.confirm_new_password}
+              onChange={handlePasswordChange}
+              style={styles.input}
+              required
+              minLength="6"
+            />
+          </div>
+          <button type="submit" style={{...styles.button, ...(loadingPassword && styles.buttonDisabled)}} disabled={loadingPassword}>
+            {loadingPassword ? 'Cambiando...' : 'Cambiar Contraseña'}
+          </button>
+        </form>
+      </div>
+       <div style={{ textAlign: 'center', marginTop: '2rem' }}>
+        <Link to="/docente/dashboard" className="secondary-link">Volver al Panel</Link>
+      </div>
+    </div>
+  );
+};
+
+export default TeacherProfilePage;


### PR DESCRIPTION
This commit introduces profile management capabilities for both teachers and students, enabling them to view and update their personal information and change their passwords.

Key changes include:

Backend:
- Added `teachers` table to the database.
- Updated `students` table to include `password_hash` and `photo_url`.
- Implemented bcryptjs for password hashing and comparison for both user roles.
- Created new API endpoints for:
  - Teacher: GET/PUT /api/teachers/profile, PUT /api/teachers/password
  - Student: GET/PUT /api/student/profile, PUT /api/student/password
- Updated student registration to use hashed passwords.
- Updated student dashboard data endpoint to fetch real photo URLs.

Frontend:
- Added "Mi Perfil" links to teacher and student dashboards.
- Created `TeacherProfilePage.jsx` for teachers to:
  - View and edit their name, nickname, email, and cellphone.
  - Change their password.
  - View a photo placeholder.
- Created `StudentProfilePage.jsx` for students to:
  - View and edit nickname, email, phone, guardian info, medical info, and emergency contact details.
  - Change their password.
  - View their photo (from photo_url) or a placeholder.
- Added necessary routing and navigation for profile pages.

Photo upload functionality is currently a placeholder and will be addressed in a future update. Placeholder password hashes in init.sql need to be replaced with actual hashes for seeded users in a development/testing environment.