### PR TITLE
fix: Attempt to resolve teacher dashboard 500 error

### DIFF
--- a/backend/routes/teacherRoutes.js
+++ b/backend/routes/teacherRoutes.js
@@ -17,7 +17,7 @@ router.get('/profile', authMiddleware, async (req, res) => {
   try {
     const result = await pool.query(
       'SELECT id, full_name, nickname, email, cellphone_number, photo_url FROM teachers WHERE id = $1',
-      [req.user.id]
+      [parseInt(req.user.id, 10)] // Explicitly parse id to integer
     );
 
     if (result.rows.length === 0) {


### PR DESCRIPTION
Applied parseInt to teacher ID in the profile fetching endpoint (/api/teachers/profile) within teacherRoutes.js. This is a precautionary measure to prevent potential type mismatches when querying the database, where the 'id' column in the 'teachers' table is an integer.

This change aims to address the 500 Internal Server Error observed on the Teacher Dashboard. Further investigation using backend logs would be needed if this does not resolve the issue or for the Student Dashboard error.