### PR TITLE
Fix: Correct frontend import paths for config.js and dateUtils.js

### DIFF
--- a/frontend/src/pages/DisabledStudentListPage.jsx
+++ b/frontend/src/pages/DisabledStudentListPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
-import { API_BASE_URL } from '../../config'; // Importar URL base
+import { API_BASE_URL } from "../config"; // Corregir ruta de importación
 
 // Iconos SVG
 const EnableIcon = () => <svg className="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="16" height="16"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd" /></svg>;

--- a/frontend/src/pages/PublicRegistrationPage.jsx
+++ b/frontend/src/pages/PublicRegistrationPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
-import { API_BASE_URL } from '../../config'; // Importar URL base
+import { API_BASE_URL } from "../config"; // Corregir ruta de importación
 
 const PublicRegistrationPage = () => {
   const initialFormData = {

--- a/frontend/src/pages/StudentDashboardPage.jsx
+++ b/frontend/src/pages/StudentDashboardPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import { useNavigate, Link } from 'react-router-dom';
-import { API_BASE_URL } from '../../config'; // Importar URL base
+import { API_BASE_URL } from "../config"; // Corregir ruta de importación
 
 // Iconos SVG
 const LogoutIcon = () => <svg className="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="16" height="16"><path fillRule="evenodd" d="M3 3.25A2.25 2.25 0 015.25 1h5.5A2.25 2.25 0 0113 3.25V4.5a.75.75 0 01-1.5 0V3.25a.75.75 0 00-.75-.75h-5.5a.75.75 0 00-.75.75v13.5a.75.75 0 00.75.75h5.5a.75.75 0 00.75-.75v-1.25a.75.75 0 011.5 0V16.75a2.25 2.25 0 01-2.25 2.25h-5.5A2.25 2.25 0 013 16.75V3.25zm10.97 9.22a.75.75 0 001.06-1.06l-1.72-1.72h3.44a.75.75 0 000-1.5H12.81l1.72-1.72a.75.75 0 00-1.06-1.06l-3 3a.75.75 0 000 1.06l3 3z" clipRule="evenodd" /></svg>;

--- a/frontend/src/pages/StudentListPage.jsx
+++ b/frontend/src/pages/StudentListPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import { Link, useNavigate } from 'react-router-dom';
-import { API_BASE_URL } from '../../config'; // Importar URL base
+import { API_BASE_URL } from "../config"; // Corregir ruta de importación
 
 // Iconos SVG (ejemplos)
 const AddIcon = () => <svg className="icon" viewBox="0 0 20 20" fill="currentColor" width="16" height="16"><path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z" /></svg>;

--- a/frontend/src/pages/StudentLoginPage.jsx
+++ b/frontend/src/pages/StudentLoginPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import axios from 'axios';
-import { API_BASE_URL } from '../../config'; // Importar URL base
+import { API_BASE_URL } from "../config"; // Corregir ruta de importación
 
 const ArrowRightOnRectangleIcon = () => (
   <svg className="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="20" height="20">

--- a/frontend/src/pages/TeacherAttendancePage.jsx
+++ b/frontend/src/pages/TeacherAttendancePage.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
-import { getCurrentPeruDateTimeObject, getTodayPeruDateString } from '../../utils/dateUtils'; // Importar funciones de fecha
-import { API_BASE_URL } from '../../config'; // Importar URL base de la API
+import { getCurrentPeruDateTimeObject, getTodayPeruDateString } from "../utils/dateUtils"; // Corregir ruta
+import { API_BASE_URL } from "../config"; // Corregir ruta
 
 // Iconos
 const GiftIcon = () => <svg className="icon" viewBox="0 0 20 20" fill="currentColor" width="16" height="16" style={{verticalAlign: 'middle', marginRight: '0.5em'}}><path d="M10 1.5a1.5 1.5 0 00-1.5 1.5v1.233A5.003 5.003 0 005.78 7.52L3.666 9.634a.75.75 0 000 1.06L9.25 16.28a.75.75 0 001.06 0L16.333 10.7a.75.75 0 000-1.061L14.221 7.52c-.902-.903-2.148-1.498-3.471-1.724V3a1.5 1.5 0 00-1.5-1.5c-.396 0-.772.156-1.06.439A1.5 1.5 0 0010 1.5zm0 3.417a3.5 3.5 0 013.231 2.066l.06.112L15.03 8.833l-5.03 5.03-1.739-1.739.011-.01.68-.68a3.502 3.502 0 012.048-5.006V4.917zM10 18a.75.75 0 000-1.5.75.75 0 000 1.5z" /></svg>;

--- a/frontend/src/pages/TeacherLoginPage.jsx
+++ b/frontend/src/pages/TeacherLoginPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
-import { API_BASE_URL } from '../../config'; // Importar URL base
+import { API_BASE_URL } from "../config"; // Corregir ruta de importación
 
 const ArrowRightOnRectangleIcon = () => (
   <svg className="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="20" height="20">

--- a/frontend/src/pages/TeacherProfilePage.jsx
+++ b/frontend/src/pages/TeacherProfilePage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import axios from 'axios';
-import { API_BASE_URL as TEACHER_API_URL_BASE } from '../../config'; // Usar alias para claridad si es necesario
+import { API_BASE_URL as TEACHER_API_URL_BASE } from "../config"; // Corregir ruta de importación
 
 // Basic styling (can be moved to App.css or a dedicated CSS file)
 const styles = {

--- a/frontend/src/pages/TeacherScoresPage.jsx
+++ b/frontend/src/pages/TeacherScoresPage.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
-import { getTodayPeruDateString as getTodayPeruDateStringForScores } from '../../utils/dateUtils'; // Renombrar para evitar colisión si se importa otra
-import { API_BASE_URL } from '../../config';
+import { getTodayPeruDateString as getTodayPeruDateStringForScores } from "../utils/dateUtils"; // Corregir ruta
+import { API_BASE_URL } from "../config"; // Corregir ruta
 
 // Iconos
 const SaveIcon = () => <svg className="icon" viewBox="0 0 20 20" fill="currentColor" width="16" height="16" style={{verticalAlign: 'middle', marginRight: '0.5em'}}><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm.75-11.25a.75.75 0 00-1.5 0v2.5h-2.5a.75.75 0 000 1.5h2.5v2.5a.75.75 0 001.5 0v-2.5h2.5a.75.75 0 000-1.5h-2.5v-2.5z" clipRule="evenodd" /></svg>;


### PR DESCRIPTION
- Changed import paths from '../../config' to '../config'.
- Changed import paths from '../../utils/dateUtils' to '../utils/dateUtils'.

This resolves errors where Vite could not find these modules due to incorrect relative paths from files within the 'src/pages/' directory.