### PR TITLE
Fix: Configure SSL for PostgreSQL connection

### DIFF
--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -7,6 +7,9 @@ const pool = new Pool({
   host: process.env.DB_HOST,
   port: process.env.DB_PORT,
   database: process.env.DB_NAME,
+  ssl: {
+    rejectUnauthorized: false // Necessary for services like Render/Neon that handle SSL termination
+  }
 });
 
 module.exports = pool;


### PR DESCRIPTION
Added `ssl: { rejectUnauthorized: false }` to the database pool configuration in `backend/config/db.js`.

This is required to establish a secure connection to Neon DB on Render, addressing the 'connection is insecure (try using `sslmode=require`)' error.