### PR TITLE
Fix: Utiliza API_BASE_URL globalmente en el frontend

### DIFF
--- a/frontend/src/pages/StudentScoresDetailPage.jsx
+++ b/frontend/src/pages/StudentScoresDetailPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
+import { API_BASE_URL } from '../config'; // Importar API_BASE_URL
 
 // Icono para el botón
 const ReportIcon = () => <svg className="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="16" height="16"><path fillRule="evenodd" d="M15.992 2.012a.75.75 0 01.75.75v14.476a.75.75 0 01-1.28.53l-4.154-4.155a.75.75 0 00-1.06 0L5.53 17.773a.75.75 0 01-1.28-.531V2.762a.75.75 0 01.75-.75h10.992zM8.75 9.25a.75.75 0 000 1.5h2.5a.75.75 0 000-1.5h-2.5z" clipRule="evenodd" /></svg>;
@@ -20,7 +21,7 @@ const StudentScoresDetailPage = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
-  const API_URL = 'http://localhost:3001/api';
+  // const API_URL = 'http://localhost:3001/api'; // Eliminar esta línea
   const getToken = useCallback(() => localStorage.getItem('studentToken'), []);
 
   // Efecto para obtener el nombre del estudiante una sola vez
@@ -31,7 +32,7 @@ const StudentScoresDetailPage = () => {
         try {
           // Asumimos que la ruta /student/dashboard-data devuelve studentInfo.full_name
           // Esto es solo para obtener el nombre para el título, no es crítico si falla.
-          const response = await axios.get(`${API_URL}/student/dashboard-data`, { headers: { 'x-auth-token': token } });
+          const response = await axios.get(`${API_BASE_URL}/student/dashboard-data`, { headers: { 'x-auth-token': token } });
           if (response.data && response.data.studentInfo) {
             setStudentName(response.data.studentInfo.full_name);
           }
@@ -41,7 +42,7 @@ const StudentScoresDetailPage = () => {
       }
     };
     fetchStudentName();
-  }, [getToken, API_URL]);
+  }, [getToken]); // API_BASE_URL es constante global, no necesita ser dependencia
 
 
   const handleFetchScoreDetails = useCallback(async () => {
@@ -56,13 +57,13 @@ const StudentScoresDetailPage = () => {
       dateParam = selectedMonth;
     }
     try {
-      const response = await axios.get(`${API_URL}/student/my-scores-summary`, {
+      const response = await axios.get(`${API_BASE_URL}/student/my-scores-summary`, {
         params: { type: queryType, date: dateParam }, headers: { 'x-auth-token': token },
       });
       setScoreDetails(response.data.records || []);
     } catch (err) { console.error("Error fetching score details:", err); setError(err.response?.data?.message || 'Error al cargar el detalle de puntajes.');}
     finally { setLoading(false); }
-  }, [getToken, API_URL, queryType, selectedDate, selectedMonth]);
+  }, [getToken, queryType, selectedDate, selectedMonth]); // API_BASE_URL es constante global
 
   // Cargar detalles iniciales al montar la página (para la fecha/mes por defecto)
   useEffect(() => {

--- a/frontend/src/pages/TeacherRankingPage.jsx
+++ b/frontend/src/pages/TeacherRankingPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
+import { API_BASE_URL } from '../config'; // Importar API_BASE_URL
 
 const TrophyIcon = () => <svg className="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="16" height="16"><path fillRule="evenodd" d="M15.28 4.72a.75.75 0 010 1.06l-2.5 2.5a.75.75 0 01-1.06 0l-1-1a.75.75 0 111.06-1.06l.47.47L14.22 4.72a.75.75 0 011.06 0zm-4.78 4.03a.75.75 0 01-1.06 0l-1-1a.75.75 0 111.06-1.06l.47.47 2.5-2.5a.75.75 0 011.06 1.06l-3 3.001zM5.78 8.72a.75.75 0 010-1.06l2.5-2.5a.75.75 0 011.06 0L11.28 7.1a.75.75 0 11-1.06 1.06l-.47-.47-2.5 2.5a.75.75 0 01-1.06 0zM2.5 13.25a.75.75 0 01.75-.75h13.5a.75.75 0 010 1.5H3.25a.75.75 0 01-.75-.75zM3 15.25a.75.75 0 01.75-.75h12.5a.75.75 0 010 1.5H3.75a.75.75 0 01-.75-.75zM2 18a.75.75 0 000 1.5h16a.75.75 0 000-1.5H2z" clipRule="evenodd" /></svg>;
 
@@ -10,7 +11,7 @@ const TeacherRankingPage = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
-  const API_URL = 'http://localhost:3001/api';
+  // const API_URL = 'http://localhost:3001/api'; // Eliminar esta línea
   const getToken = useCallback(() => localStorage.getItem('teacherToken'), []);
 
   const fetchRanking = useCallback(async (monthToFetch) => {
@@ -18,13 +19,14 @@ const TeacherRankingPage = () => {
     setLoading(true); setError('');
     try {
       const token = getToken();
-      const response = await axios.get(`${API_URL}/reports/monthly-ranking`, {
+      // Usar API_BASE_URL para construir la URL de la solicitud
+      const response = await axios.get(`${API_BASE_URL}/reports/monthly-ranking`, {
         params: { month: monthToFetch }, headers: { 'x-auth-token': token },
       });
       setRankingData(response.data.ranking || []);
     } catch (err) { console.error("Error fetching ranking:", err); setError(err.response?.data?.message || 'Error al cargar el ranking.'); setRankingData([]); }
     finally { setLoading(false); }
-  }, [getToken, API_URL]);
+  }, [getToken]); // Eliminar API_URL de las dependencias, API_BASE_URL es constante y no necesita estar aquí
 
   useEffect(() => { fetchRanking(selectedMonth); }, [fetchRanking, selectedMonth]);
 

--- a/frontend/src/pages/TeacherSummaryPage.jsx
+++ b/frontend/src/pages/TeacherSummaryPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
+import { API_BASE_URL } from '../config'; // Importar API_BASE_URL
 
 // Icono para el botón
 const ReportIcon = () => <svg className="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="16" height="16"><path fillRule="evenodd" d="M15.992 2.012a.75.75 0 01.75.75v14.476a.75.75 0 01-1.28.53l-4.154-4.155a.75.75 0 00-1.06 0L5.53 17.773a.75.75 0 01-1.28-.531V2.762a.75.75 0 01.75-.75h10.992zM8.75 9.25a.75.75 0 000 1.5h2.5a.75.75 0 000-1.5h-2.5z" clipRule="evenodd" /></svg>;
@@ -17,19 +18,20 @@ const TeacherSummaryPage = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
-  const API_URL = 'http://localhost:3001/api';
+  // const API_URL = 'http://localhost:3001/api'; // Eliminar esta línea
   const getToken = useCallback(() => localStorage.getItem('teacherToken'), []);
 
   useEffect(() => {
     const fetchStudents = async () => {
       try {
         const token = getToken();
-        const response = await axios.get(`${API_URL}/admin/students?active=true`, { headers: { 'x-auth-token': token } });
+        // Usar API_BASE_URL para construir la URL de la solicitud
+        const response = await axios.get(`${API_BASE_URL}/admin/students?active=true`, { headers: { 'x-auth-token': token } });
         setStudents(response.data);
       } catch (err) { console.error("Error fetching students:", err); setError(err.response?.data?.message || 'Error al cargar estudiantes.'); }
     };
     fetchStudents();
-  }, [getToken, API_URL]);
+  }, [getToken]); // API_BASE_URL es constante global, no necesita ser dependencia
 
   const handleFetchSummary = async () => {
     setLoading(true); setError(''); setSummaryData(null);
@@ -38,10 +40,12 @@ const TeacherSummaryPage = () => {
       let response;
       if (summaryType === 'student_monthly') {
         if (!selectedStudent || !selectedMonth) { setError('Por favor, seleccione un estudiante y un mes.'); setLoading(false); return; }
-        response = await axios.get(`${API_URL}/reports/student-summary`, { params: { studentId: selectedStudent, month: selectedMonth }, headers });
+        // Usar API_BASE_URL para construir la URL de la solicitud
+        response = await axios.get(`${API_BASE_URL}/reports/student-summary`, { params: { studentId: selectedStudent, month: selectedMonth }, headers });
       } else {
         if (!selectedDate) { setError('Por favor, seleccione una fecha.'); setLoading(false); return; }
-        response = await axios.get(`${API_URL}/reports/daily-summary`, { params: { date: selectedDate }, headers });
+        // Usar API_BASE_URL para construir la URL de la solicitud
+        response = await axios.get(`${API_BASE_URL}/reports/daily-summary`, { params: { date: selectedDate }, headers });
       }
       setSummaryData(response.data);
     } catch (err) { console.error("Error fetching summary:", err); setError(err.response?.data?.message || 'Error al cargar el resumen.'); }


### PR DESCRIPTION
- Actualiza StudentScoresDetailPage.jsx y TeacherSummaryPage.jsx para usar API_BASE_URL desde config.js, eliminando URLs hardcodeadas.
- Asegura que todas las llamadas a la API en las páginas usen la configuración centralizada.