### PR TITLE
Fix: Return generated password in add-quick student response

### DIFF
--- a/backend/routes/studentAdminRoutes.js
+++ b/backend/routes/studentAdminRoutes.js
@@ -91,7 +91,9 @@ router.post('/add-quick', async (req, res) => {
     );
 
     await client.query('COMMIT');
-    res.status(201).json(newStudentResult.rows[0]);
+    // Incluir defaultPassword en la respuesta
+    const studentData = newStudentResult.rows[0];
+    res.status(201).json({ ...studentData, defaultPassword });
 
   } catch (err) {
     await client.query('ROLLBACK');


### PR DESCRIPTION
The 'add-quick' endpoint for administrators now includes the generated default password in the JSON response. This allows the administrator to immediately know the credentials for the newly created student.

This addresses the issue where credentials were generated but not communicated back to the admin, making it difficult to inform the student of their login details.