### PR TITLE
Fix: Use explicit colors for student summary box

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1196,38 +1196,38 @@ input:checked + .toggle-slider:before {
 }
 
 .summary-info-card { /* Tarjeta para el resumen de puntaje y casting */
-  background-color: var(--container-background) !important; /* Intentar forzar el fondo oscuro */
+  background-color: rgba(30, 30, 50, 0.75) !important; /* Valor explícito para --container-background */
   padding: 1.5rem 2rem;
   border-radius: var(--border-radius-medium);
   margin-bottom: 2rem;
   box-shadow: 0 6px 25px rgba(0, 0, 0, 0.25);
-  border: 2px solid var(--primary-color-student);
-  color: var(--text-color-main) !important; /* Forzar color de texto principal claro */
+  border: 2px solid #3498DB !important; /* Valor explícito para --primary-color-student */
+  color: #E0E0E0 !important; /* Valor explícito para --text-color-main */
 }
 
 .summary-info-card .section-title { /* Para "Resumen del Mes" */
   margin-top: 0;
   margin-bottom: 1.5rem;
   font-size: 1.4rem;
-  color: var(--primary-color-student) !important; /* Forzar color del título */
+  color: #3498DB !important; /* Valor explícito para --primary-color-student */
   padding-bottom: 0.75rem;
-  border-bottom: 1px solid var(--border-color-subtle);
+  border-bottom: 1px solid #4A4A60 !important; /* Valor explícito para --border-color-subtle */
   font-weight: 600;
 }
 
 .summary-info-card p {
   margin-bottom: 0.8rem;
   font-size: 1rem;
-  color: var(--text-color-main) !important; /* Forzar color de texto de párrafos */
+  color: #E0E0E0 !important; /* Valor explícito para --text-color-main */
 }
 
 .summary-info-card p strong {
-  color: var(--text-color-light) !important; /* Forzar color de texto strong más claro */
+  color: #FFFFFF !important; /* Valor explícito para --text-color-light */
 }
 
 .summary-info-card .total-points-value { /* Clase específica para el valor de los puntos */
   font-size: 1.3em;
-  color: var(--primary-color-student) !important; /* Forzar color de puntos */
+  color: #3498DB !important; /* Valor explícito para --primary-color-student */
   font-weight: bold;
 }
 


### PR DESCRIPTION
Replaces CSS variables with explicit hex/rgba color values for the student dashboard's monthly summary box. This is an attempt to resolve a persistent issue where the box renders with a white background despite styles for a dark theme, even when using `!important` with variables.

This change aims to eliminate CSS variable resolution as a potential cause. `!important` is kept temorarily for diagnostic purposes.

Colors used:
- Background: rgba(30, 30, 50, 0.75)
- Border & accents: #3498DB
- Main text: #E0E0E0
- Strong text: #FFFFFF