### PR TITLE
Fix: Apply dark theme to monthly summary in StudentScoresDetailPage

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1196,73 +1196,57 @@ input:checked + .toggle-slider:before {
 }
 
 .summary-info-card { /* Tarjeta para el resumen de puntaje y casting */
-  background-color: rgba(30, 30, 50, 0.75) !important; /* Valor explícito para --container-background */
+  background-color: var(--container-background);
   padding: 1.5rem 2rem;
   border-radius: var(--border-radius-medium);
   margin-bottom: 2rem;
-  box-shadow: 0 6px 25px rgba(0, 0, 0, 0.25);
-  border: 2px solid #3498DB !important; /* Valor explícito para --primary-color-student */
-  color: #E0E0E0 !important; /* Valor explícito para --text-color-main */
+  box-shadow: 0 6px 20px rgba(0,0,0,0.15);
+  border: 1px solid var(--border-color-subtle);
 }
 
-.summary-info-card .section-title { /* Para "Resumen del Mes" */
-  margin-top: 0;
-  margin-bottom: 1.5rem;
-  font-size: 1.4rem;
-  color: #3498DB !important; /* Valor explícito para --primary-color-student */
-  padding-bottom: 0.75rem;
-  border-bottom: 1px solid #4A4A60 !important; /* Valor explícito para --border-color-subtle */
-  font-weight: 600;
-}
-
-.summary-info-card p {
-  margin-bottom: 0.8rem;
-  font-size: 1rem;
-  color: #E0E0E0 !important; /* Valor explícito para --text-color-main */
-}
-
-.summary-info-card p strong {
-  color: #FFFFFF !important; /* Valor explícito para --text-color-light */
-}
-
-.summary-info-card .total-points-value { /* Clase específica para el valor de los puntos */
-  font-size: 1.3em;
-  color: #3498DB !important; /* Valor explícito para --primary-color-student */
-  font-weight: bold;
-}
-
-.summary-info-card .casting-status-apto { color: var(--color-success); font-weight: bold; }
-.summary-info-card .casting-status-evaluacion { color: var(--color-warning); font-weight: bold; }
-.summary-info-card .casting-status-no-apto { color: var(--color-danger); font-weight: bold; }
-
-
-/* Estilos para el cuadro de resumen mensual en StudentScoresDetailPage - Estos no se modifican */
+/* Estilos para el cuadro de resumen mensual en StudentScoresDetailPage */
 .monthly-summary-info {
   text-align: center;
-  margin: 1rem 0;
-  padding: 1rem;
-  background-color: #f8f9fa; /* Gris claro */
-  border-radius: 8px;
-  border: 1px solid #e0e0e0; /* Un borde sutil */
-  color: #333; /* Color de texto oscuro para contraste */
+  margin: 2rem auto; /* Más margen vertical y centrado horizontalmente */
+  padding: 1.5rem 2rem; /* Más padding */
+  background-color: var(--container-background); /* Fondo oscuro del tema */
+  border-radius: var(--border-radius-medium); /* Bordes redondeados consistentes */
+  border: 1px solid var(--primary-color-student); /* Borde con color primario del estudiante */
+  color: var(--text-color-main); /* Color de texto principal claro */
+  max-width: 600px; /* Limitar ancho para mejor lectura */
+  box-shadow: 0 6px 20px rgba(0,0,0,0.15); /* Sombra sutil */
 }
 
 .monthly-summary-info h3 {
   margin-top: 0;
-  color: #0056b3; /* Un azul para el título, similar al de los botones de acción */
-  font-size: 1.25rem; /* Tamaño de fuente para el título del resumen */
-  margin-bottom: 0.75rem;
+  color: var(--primary-color-student); /* Título con color primario del estudiante */
+  font-size: 1.4rem; /* Un poco más grande */
+  margin-bottom: 1rem; /* Más espacio inferior */
 }
 
 .monthly-summary-info p {
-  margin-bottom: 0.5rem;
-  font-size: 1rem; /* Tamaño de fuente para el texto del resumen */
-  color: #333; /* Asegurar que el texto de los párrafos también sea oscuro aquí */
+  margin-bottom: 0.75rem; /* Un poco más de espacio entre párrafos */
+  font-size: 1.1rem; /* Texto ligeramente más grande para legibilidad */
+  color: var(--text-color-main); /* Asegurar color de texto claro */
 }
 
 .monthly-summary-info p strong {
-  color: #004085; /* Un azul un poco más oscuro para los labels "Puntaje Total" y "Puesto" */
+  color: var(--text-color-light); /* Labels (strong) en blanco para mayor contraste */
+  font-weight: 600; /* Ligeramente más bold */
 }
+.summary-info-card .section-title { /* Para "Resumen del Mes" */
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  font-size: 1.4rem;
+  color: var(--primary-color-student); /* Azul para títulos de sección de estudiante */
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border-color-subtle);
+  font-weight: 600;
+}
+.summary-info-card p { margin-bottom: 0.8rem; font-size: 1rem; }
+.summary-info-card .casting-status-apto { color: var(--color-success); font-weight: bold; }
+.summary-info-card .casting-status-evaluacion { color: var(--color-warning); font-weight: bold; }
+.summary-info-card .casting-status-no-apto { color: var(--color-danger); font-weight: bold; }
 
 .student-dashboard .dashboard-actions-grid {
   grid-template-columns: 1fr; /* Para que "Ver Mis Puntajes" ocupe todo el ancho */

--- a/frontend/src/pages/StudentDashboardPage.jsx
+++ b/frontend/src/pages/StudentDashboardPage.jsx
@@ -187,57 +187,17 @@ const StudentDashboardPage = () => {
       )}
 
       {dashboardData && ( // Ensure dashboardData is available for summary card
-        <div
-          // className="summary-info-card" // Clase eliminada temporalmente
-          style={{
-            backgroundColor: 'rgba(30, 30, 50, 0.75)', // Fondo oscuro explícito
-            padding: '1.5rem 2rem',
-            borderRadius: '16px', // var(--border-radius-medium)
-            marginBottom: '2rem',
-            boxShadow: '0 6px 25px rgba(0, 0, 0, 0.25)',
-            border: '2px solid #3498DB', // Borde azul explícito
-            color: '#E0E0E0' // Color de texto principal explícito
-          }}
-        >
-          <h4
-            // className="section-title" // Clase eliminada temporalmente
-            style={{
-              marginTop: 0,
-              marginBottom: '1.5rem',
-              fontSize: '1.4rem',
-              color: '#3498DB', // Color de título azul explícito
-              paddingBottom: '0.75rem',
-              borderBottom: '1px solid #4A4A60', // Borde inferior explícito
-              fontWeight: 600
-            }}
-          >
-            Resumen del Mes ({currentMonth})
-          </h4>
-          <p style={{ marginBottom: '0.8rem', fontSize: '1rem', color: '#E0E0E0' }}>
-            <strong style={{ color: '#FFFFFF' }}>Puntaje Total del Mes:</strong>{' '}
-            <span
-              // className="total-points-value" // Clase eliminada temporalmente
-              style={{
-                fontSize: '1.3em',
-                color: '#3498DB', // Color de puntos azul explícito
-                fontWeight: 'bold'
-              }}
-            >
-              {monthlyTotalPoints !== null ? monthlyTotalPoints : 'N/A'}
-            </span> puntos
-          </p>
-          <p style={{ marginBottom: '0.8rem', fontSize: '1rem', color: '#E0E0E0' }}>
-            <strong style={{ color: '#FFFFFF' }}>Estado de Acceso a Casting: </strong>
-            <span className={getCastingStatusClassName()} style={
-              castingStatus === 'APTO' ? { color: '#28A745', fontWeight: 'bold' } : // Verde explícito
-              castingStatus === 'EN EVALUACIÓN' ? { color: '#F39C12', fontWeight: 'bold' } : // Naranja explícito
-              { color: '#D9534F', fontWeight: 'bold' } // Rojo explícito (para NO APTO o default)
-            }>
+        <div className="summary-info-card">
+          <h4 className="section-title">Resumen del Mes ({currentMonth})</h4>
+          <p><strong>Puntaje Total del Mes:</strong> <span style={{fontSize: '1.3em', color: 'var(--primary-color-student)', fontWeight: 'bold'}}>{monthlyTotalPoints !== null ? monthlyTotalPoints : 'N/A'}</span> puntos</p>
+          <p>
+            <strong>Estado de Acceso a Casting: </strong>
+            <span className={getCastingStatusClassName()}>
               {castingStatus || 'No disponible'}
             </span>
           </p>
-          <p style={{ marginTop: '1rem', fontSize: '1rem', color: '#E0E0E0' }}>
-            <strong style={{ color: '#FFFFFF' }}>Feedback del Ranking:</strong> {rankingInfo.message}
+          <p style={{marginTop: '1rem'}}>
+            <strong>Feedback del Ranking:</strong> {rankingInfo.message}
           </p>
         </div>
       )}

--- a/frontend/src/pages/StudentScoresDetailPage.jsx
+++ b/frontend/src/pages/StudentScoresDetailPage.jsx
@@ -128,7 +128,8 @@ const StudentScoresDetailPage = () => {
       {loading ? <div className="text-center" style={{padding: "2rem"}}>Cargando detalles...</div> : (
         <>
           {queryType === 'monthly' && monthlyTotalPoints !== null && (
-            <div className="monthly-summary-info" style={{ textAlign: 'center', margin: '1rem 0', padding: '1rem', backgroundColor: '#f0f0f0', borderRadius: '8px' }}>
+            // Se eliminan los estilos inline para permitir que App.css controle la apariencia
+            <div className="monthly-summary-info">
               <h3>Resumen del Mes: {selectedMonth}</h3>
               <p><strong>Puntaje Total del Mes:</strong> {monthlyTotalPoints}</p>
               {rankingPosition !== null && <p><strong>Puesto en el Ranking Mensual:</strong> {rankingPosition}</p>}


### PR DESCRIPTION
This commit corrects the styling of the monthly summary box on the student's detailed scores page (`StudentScoresDetailPage.jsx`).

Previously, this box had inline styles फोर्सing a light background (#f0f0f0) and its corresponding CSS class (`.monthly-summary-info`) in `App.css` also defined a light theme.

Changes:
1. Removed inline styles from the `div` in `StudentScoresDetailPage.jsx`.
2. Updated the `.monthly-summary-info` class and its child element styles in `App.css` to use the application's dark theme variables:
    - Background set to `var(--container-background)`.
    - Text colors set to `var(--text-color-main)` and `var(--text-color-light)`.
    - Accent colors (titles, border) set to `var(--primary-color-student)`.

This should resolve the issue where the user saw a white background and blue text, ensuring the component now harmonizes with the overall dark theme of the application.