### PR TITLE
Fix: Prevenir bono de ranking si el mes anterior no tiene puntajes po…

### DIFF
--- a/backend/routes/reportRoutes.js
+++ b/backend/routes/reportRoutes.js
@@ -251,7 +251,11 @@ router.get('/monthly-ranking', async (req, res) => {
             LIMIT 10;
         `;
         const prevRankingResult = await client.query(prevRankingQuery, [prevMonthString]);
-        top10PreviousMonthIDs = prevRankingResult.rows.map(r => r.student_id);
+        // Solo asignar IDs para el bono si hay resultados y el puntaje máximo del mes anterior es > 0
+        if (prevRankingResult.rows.length > 0 && prevRankingResult.rows[0].grand_total_points > 0) {
+            top10PreviousMonthIDs = prevRankingResult.rows.map(r => r.student_id);
+        }
+        // Si no, top10PreviousMonthIDs permanece vacío, y no se aplicará bono.
     }
 
 


### PR DESCRIPTION
…sitivos

Se ajustó la lógica en la ruta GET /api/reports/monthly-ranking. Ahora, la bonificación para el top 10 del mes anterior solo se aplica si:
1. La consulta del ranking del mes anterior devuelve algún estudiante.
2. El puntaje más alto (`grand_total_points`) entre esos estudiantes es mayor que 0.

Esto evita que se otorguen bonificaciones basadas en meses sin actividad registrada o donde todos los puntajes calculados son cero, corrigiendo el problema donde se sumaban puntos por bonificaciones inexistentes cuando el sistema se inicia o después de meses sin datos.