### PR TITLE
feat: Implement camera stream on attendance page

### DIFF
--- a/frontend/src/pages/CameraAttendancePage.jsx
+++ b/frontend/src/pages/CameraAttendancePage.jsx
@@ -1,12 +1,62 @@
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 
 const CameraAttendancePage = () => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const videoRef = useRef(null);
+
+  useEffect(() => {
+    const videoElement = videoRef.current; // Capture videoRef.current
+
+    const startCamera = async () => {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+        if (videoElement) {
+          videoElement.srcObject = stream;
+        }
+      } catch (err) {
+        let errorMessage = 'Ocurrió un error al acceder a la cámara.';
+        if (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError') {
+          errorMessage = 'Permiso para acceder a la cámara denegado. Por favor, habilita el acceso en la configuración de tu navegador.';
+        } else if (err.name === 'NotFoundError' || err.name === 'DevicesNotFoundError') {
+          errorMessage = 'No se encontró ninguna cámara web en tu dispositivo.';
+        }
+        setError(errorMessage);
+        setLoading(false); // Set loading to false only on error
+      }
+    };
+
+    startCamera();
+
+    return () => {
+      // Cleanup using the captured value
+      if (videoElement && videoElement.srcObject) {
+        const stream = videoElement.srcObject;
+        const tracks = stream.getTracks();
+        tracks.forEach(track => track.stop());
+      }
+    };
+  }, []); // Empty dependency array ensures this effect runs only once on mount
+
   return (
-    <div>
-      <h1>Camera Attendance Page</h1>
-      <p>This page is under construction.</p>
-      <Link to="/teacher/dashboard">Back to Dashboard</Link>
+    <div style={{ textAlign: 'center', padding: '20px' }}>
+      <h1>Asistencia por Cámara</h1>
+      <div style={{ position: 'relative', width: 'clamp(300px, 80vw, 640px)', margin: '20px auto', border: '2px solid #333', borderRadius: '8px', overflow: 'hidden' }}>
+        {loading && <div style={{ padding: '20px' }}>Cargando cámara...</div>}
+        {error && <div style={{ color: 'red', padding: '20px' }}>{error}</div>}
+        <video
+          ref={videoRef}
+          autoPlay
+          playsInline
+          muted
+          style={{ width: '100%', height: 'auto', display: loading || error ? 'none' : 'block', verticalAlign: 'middle' }}
+          onCanPlay={() => setLoading(false)}
+        />
+      </div>
+      <div style={{ marginTop: '20px' }}>
+        <Link to="/docente/dashboard" className="btn-action">Volver al Dashboard</Link>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
This commit implements the functionality to access and display the user's webcam stream on the Camera Attendance Page.

- Uses React hooks (`useState`, `useEffect`, `useRef`) to manage the component's state and the video stream.
- Displays a loading message while waiting for camera access.
- Provides user-friendly error messages if camera access is denied or if no device is found.
- Includes a cleanup function in `useEffect` to properly stop and release the camera stream when the component unmounts.
- Fixes a linting warning related to `useEffect` cleanup to ensure code quality.