### PR TITLE
feat: Add backend endpoint for student face registration

### DIFF
--- a/backend/init.sql
+++ b/backend/init.sql
@@ -19,7 +19,8 @@ CREATE TABLE students (
     medical_conditions TEXT,
     comments TEXT,
     emergency_contact_name TEXT,
-    emergency_contact_phone VARCHAR(20)
+    emergency_contact_phone VARCHAR(20),
+    face_descriptor JSONB
 );
 
 -- Insertar estudiantes con contraseñas HASHEADAS de ejemplo.


### PR DESCRIPTION
This commit introduces a new backend endpoint to handle the registration of student face descriptors.

Key changes:
- **Database Schema:** The `students` table in `backend/init.sql` has been altered to include a new `face_descriptor` column of type `JSONB`. This will store the facial recognition data.
- **New Endpoint:** A new route `POST /api/student/register-face` has been created in `backend/routes/studentRoutes.js`.
- **Controller Logic:** A new controller function `registerFaceDescriptor` has been implemented. This function:
    - Is protected to ensure only authenticated students can access it.
    - Receives and validates the face descriptor from the request body.
    - Updates the `face_descriptor` for the authenticated student in the database.
    - Returns a success or error message.