### PR TITLE
debug: Log face descriptor response

### DIFF
--- a/frontend/src/pages/CameraAttendancePage.jsx
+++ b/frontend/src/pages/CameraAttendancePage.jsx
@@ -41,6 +41,10 @@ const CameraAttendancePage = () => {
           headers: { 'x-auth-token': token }
         });
 
+        // --- ¡AÑADE ESTA LÍNEA PARA DEPURAR! ---
+        console.log('Respuesta completa del servidor:', response.data);
+        // ----------------------------------------
+
         if (response.data && response.data.length > 0) {
           // Guardar los descriptores crudos
           setLabeledDescriptors(response.data);


### PR DESCRIPTION
This commit adds a `console.log` statement to the `CameraAttendancePage.jsx` component to log the full response from the `/api/admin/students/all-face-descriptors` endpoint.

This is intended for debugging purposes to inspect the structure and content of the data being returned from the server.