### PR TITLE
fix(camera): Fix crash on camera attendance page

### DIFF
--- a/frontend/src/pages/CameraAttendancePage.jsx
+++ b/frontend/src/pages/CameraAttendancePage.jsx
@@ -26,8 +26,7 @@ const CameraAttendancePage = () => {
           faceapi.nets.tinyFaceDetector.loadFromUri(MODEL_URL),
           faceapi.nets.faceLandmark68Net.loadFromUri(MODEL_URL),
           faceapi.nets.faceRecognitionNet.loadFromUri(MODEL_URL),
-          faceapi.nets.faceExpressionNet.loadFromUri(MODEL_URL),
-          faceapi.nets.faceDescriptorExtractor.loadFromUri(MODEL_URL)
+          faceapi.nets.faceExpressionNet.loadFromUri(MODEL_URL)
         ]);
         setIaModelsLoaded(true);
 


### PR DESCRIPTION
Removes the attempt to load a non-existent `faceDescriptorExtractor` model from `face-api.js`. This model does not exist in the library and was causing a `TypeError` on the camera attendance page, preventing the feature from working.

The `face-api.js` library computes face descriptors using the `faceRecognitionNet` model, which is already being loaded. There is no separate `faceDescriptorExtractor` model to load.