### PR TITLE
fix(frontend): Correct camera mirror effect

### DIFF
--- a/frontend/src/pages/CameraAttendancePage.jsx
+++ b/frontend/src/pages/CameraAttendancePage.jsx
@@ -232,7 +232,7 @@ const CameraAttendancePage = () => {
           autoPlay
           playsInline
           muted
-          style={{ width: '100%', height: 'auto', display: (loading || error || !iaModelsLoaded || !faceMatcher) ? 'none' : 'block', verticalAlign: 'middle' }}
+          style={{ width: '100%', height: 'auto', display: (loading || error || !iaModelsLoaded || !faceMatcher) ? 'none' : 'block', verticalAlign: 'middle', transform: 'scaleX(-1)' }}
           onCanPlay={() => setLoading(false)}
         />
         <canvas ref={canvasRef} style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} />


### PR DESCRIPTION
Adds `transform: 'scaleX(-1)'` to the video element on the `CameraAttendancePage`. This corrects the mirror effect, making the video feed appear more natural to the user, as if looking in a mirror.