### PR TITLE
fix(frontend): Improve error handling for duplicate attendance

### DIFF
--- a/frontend/src/pages/CameraAttendancePage.jsx
+++ b/frontend/src/pages/CameraAttendancePage.jsx
@@ -173,9 +173,19 @@ const CameraAttendancePage = () => {
     } catch (error) {
       // 3. Log para ver el error exacto si la petición falla
       console.error('ERROR DETALLADO al guardar asistencia:', error.response);
-
       console.error(`Error marcando asistencia para ${studentId}:`, error);
-      toast.error(`Error al marcar a ${studentName}`);
+
+      // Manejo de error específico para 409 Conflict
+      if (error.response && error.response.status === 409) {
+        toast.info(error.response.data.message || `Asistencia para ${studentName} ya fue registrada.`, {
+          duration: 3000,
+          icon: 'ℹ️',
+        });
+      } else {
+        // Manejo de error genérico para otros problemas
+        toast.error(`Error al marcar a ${studentName}`);
+      }
+
       // Si falla, quitarlo de la lista para permitir reintentos
       setRecentlyMarkedIds(prev => {
         const newSet = new Set(prev);


### PR DESCRIPTION
This commit improves the user experience on the camera attendance page.

When the backend returns a 409 Conflict status (indicating that attendance for a student has already been recorded), the frontend now catches this specific error and displays a user-friendly informational message instead of a generic error toast.

This makes the idempotent behavior of the backend clear to the user.