### PR TITLE
fix: Improve 409 error handling and finalize attendance logic

### DIFF
--- a/frontend/src/pages/CameraAttendancePage.jsx
+++ b/frontend/src/pages/CameraAttendancePage.jsx
@@ -186,12 +186,16 @@ const CameraAttendancePage = () => {
         toast.error(`Error al marcar a ${studentName}`);
       }
 
-      // Si falla, quitarlo de la lista para permitir reintentos
-      setRecentlyMarkedIds(prev => {
-        const newSet = new Set(prev);
-        newSet.delete(studentId);
-        return newSet;
-      });
+      // Si es un error 409, no queremos reintentar, ya que la asistencia SÍ está registrada.
+      // Para cualquier otro error (ej. de red), sí quitamos al estudiante de la lista
+      // para que el sistema pueda reintentar marcarlo en el siguiente intervalo.
+      if (!error.response || error.response.status !== 409) {
+        setRecentlyMarkedIds(prev => {
+          const newSet = new Set(prev);
+          newSet.delete(studentId);
+          return newSet;
+        });
+      }
     }
 
     // Permitir marcar de nuevo al mismo estudiante después de 2 minutos


### PR DESCRIPTION
This commit provides the final set of fixes for the attendance recording system.

The primary change is to the frontend error handling. The `catch` block in `CameraAttendancePage.jsx` now correctly handles the `409 Conflict` error by preventing the system from retrying the request in a loop. This is achieved by not removing the student from the `recentlyMarkedIds` set if the error is a 409, as this is an expected outcome, not a system failure.

This commit also includes the previous comprehensive refactoring of the attendance logic, which moved status and time determination to the backend and made the endpoint idempotent.