### PR TITLE
fix(frontend): Use correct toast function for info messages

### DIFF
--- a/frontend/src/pages/CameraAttendancePage.jsx
+++ b/frontend/src/pages/CameraAttendancePage.jsx
@@ -177,7 +177,7 @@ const CameraAttendancePage = () => {
 
       // Manejo de error específico para 409 Conflict
       if (error.response && error.response.status === 409) {
-        toast.info(error.response.data.message || `Asistencia para ${studentName} ya fue registrada.`, {
+        toast(error.response.data.message || `Asistencia para ${studentName} ya fue registrada.`, {
           duration: 3000,
           icon: 'ℹ️',
         });


### PR DESCRIPTION
This commit fixes a `TypeError` that was occurring in the error handling logic of the `CameraAttendancePage`.

The code was attempting to call `toast.info()`, which is not a function in the `react-hot-toast` library. This has been corrected to use the standard `toast()` function with a custom icon, which is the proper way to display an informational message.

This ensures that when the backend correctly returns a 409 Conflict status, the user sees the intended informational message instead of a crash in the console.