### PR TITLE
fix(student): Correct camera mirror effect on profile page

### DIFF
--- a/frontend/src/pages/StudentProfilePage.jsx
+++ b/frontend/src/pages/StudentProfilePage.jsx
@@ -414,7 +414,7 @@ const StudentProfilePage = () => {
               muted
               width="480"
               height="360"
-              style={{ borderRadius: '8px', display: captureStep === 'live' ? 'block' : 'none' }}
+              style={{ borderRadius: '8px', display: captureStep === 'live' ? 'block' : 'none', transform: 'scaleX(-1)' }}
             ></video>
             <canvas
               ref={canvasRef}


### PR DESCRIPTION
Adds `transform: 'scaleX(-1)'` to the video element in the face registration modal on the `StudentProfilePage`.

This makes the video feed appear more natural to the user, matching the behavior of the camera on the main attendance page and making it easier to frame their face correctly.