### PR TITLE
fix(frontend): Correctly process multiple face descriptors

### DIFF
--- a/frontend/src/pages/CameraAttendancePage.jsx
+++ b/frontend/src/pages/CameraAttendancePage.jsx
@@ -62,13 +62,19 @@ const CameraAttendancePage = () => {
 
   useEffect(() => {
     if (labeledDescriptors.length > 0) {
-      const readyDescriptors = labeledDescriptors.map(d => {
-        // Convertir el descriptor de array normal a Float32Array
-        const descriptorAsFloat32Array = Float32Array.from(d.descriptor);
-        return new faceapi.LabeledFaceDescriptors(d.label, [descriptorAsFloat32Array]);
-      });
-      const matcher = new faceapi.FaceMatcher(readyDescriptors, 0.6);
-      setFaceMatcher(matcher);
+      try {
+        const readyDescriptors = labeledDescriptors.map(d => {
+          // d.descriptor is now an array of descriptor arrays.
+          // We need to convert each one to a Float32Array.
+          const descriptorsAsFloat32Arrays = d.descriptor.map(desc => Float32Array.from(desc));
+          return new faceapi.LabeledFaceDescriptors(d.label, descriptorsAsFloat32Arrays);
+        });
+        const matcher = new faceapi.FaceMatcher(readyDescriptors, 0.6);
+        setFaceMatcher(matcher);
+      } catch (e) {
+        console.error("Error creating FaceMatcher:", e);
+        setError("Error al procesar los datos faciales. Es posible que algunos registros sean de un formato antiguo.");
+      }
     }
   }, [labeledDescriptors]);
 


### PR DESCRIPTION
This commit fixes a crash on the camera attendance page caused by an incorrect processing of face descriptor data.

When the backend was updated to provide multiple descriptors per student for improved accuracy, the frontend was not updated to handle this new data structure. It was flattening the array of descriptors, leading to a `euclideanDistance` error during face matching.

The logic in `CameraAttendancePage.jsx` has been corrected to properly map the array of descriptors, allowing the `FaceMatcher` to be created successfully.