### PR TITLE
debug(student): Log detected camera devices

### DIFF
--- a/frontend/src/pages/StudentProfilePage.jsx
+++ b/frontend/src/pages/StudentProfilePage.jsx
@@ -352,6 +352,7 @@ const StudentProfilePage = () => {
       const devices = await navigator.mediaDevices.enumerateDevices();
       const cameras = devices.filter(device => device.kind === 'videoinput');
       setVideoDevices(cameras);
+      console.log('Cámaras detectadas:', cameras.length, cameras);
       setActiveDeviceIndex(0); // Empezar con la primera cámara
 
       // 2. Resetear estado y abrir modal


### PR DESCRIPTION
Adds a `console.log` statement to the `handleOpenFaceModal` function on the `StudentProfilePage`.

This log will output the list of enumerated video devices to the console, helping to diagnose why the "Switch Camera" button may not be appearing for the user.