### PR TITLE
fix(student): Correct function order to prevent ReferenceError

### DIFF
--- a/frontend/src/pages/StudentProfilePage.jsx
+++ b/frontend/src/pages/StudentProfilePage.jsx
@@ -308,19 +308,6 @@ const StudentProfilePage = () => {
     };
     loadModels();
   }, []);
-  // Este useEffect se encargará de reiniciar el video cuando cambie la cámara seleccionada.
-  useEffect(() => {
-    if (isFaceModalOpen && videoDevices.length > 0) {
-      startVideo();
-    }
-    // Cleanup: Detener el video cuando el modal se cierra o el componente se desmonta
-    return () => {
-      if (videoRef.current && videoRef.current.srcObject) {
-        videoRef.current.srcObject.getTracks().forEach(track => track.stop());
-      }
-    };
-  }, [isFaceModalOpen, activeDeviceIndex, videoDevices, startVideo]);
-
   const startVideo = useCallback(async () => {
     if (videoDevices.length === 0) {
       console.log("No video devices found yet, startVideo will wait.");
@@ -341,6 +328,19 @@ const StudentProfilePage = () => {
       setFaceError("No se pudo acceder a la cámara. Revisa los permisos en tu navegador.");
     }
   }, [videoDevices, activeDeviceIndex]);
+
+  // Este useEffect se encargará de reiniciar el video cuando cambie la cámara seleccionada.
+  useEffect(() => {
+    if (isFaceModalOpen && videoDevices.length > 0) {
+      startVideo();
+    }
+    // Cleanup: Detener el video cuando el modal se cierra o el componente se desmonta
+    return () => {
+      if (videoRef.current && videoRef.current.srcObject) {
+        videoRef.current.srcObject.getTracks().forEach(track => track.stop());
+      }
+    };
+  }, [isFaceModalOpen, activeDeviceIndex, videoDevices, startVideo]);
 
   const handleOpenFaceModal = async () => {
     if (!faceApiLoaded) return;


### PR DESCRIPTION
This commit reorders the functions within the `StudentProfilePage` component.

The `startVideo` function, which is defined as a `useCallback`, was being called by other functions and a `useEffect` hook before its definition in the code. This created a "temporal dead zone" and resulted in a `ReferenceError` on page load.

The `startVideo` function has been moved to be defined before any of its usages, resolving the crash.