### PR TITLE
feat(camera): Apply mirror effect only to front camera

### DIFF
--- a/frontend/src/pages/CameraAttendancePage.jsx
+++ b/frontend/src/pages/CameraAttendancePage.jsx
@@ -257,6 +257,8 @@ const CameraAttendancePage = () => {
     return null;
   };
 
+  const isFrontCamera = videoDevices[activeDeviceIndex]?.label.toLowerCase().includes('front');
+
   return (
     <div style={{ textAlign: 'center', padding: '20px' }}>
       <h1>Asistencia por Cámara</h1>
@@ -273,7 +275,7 @@ const CameraAttendancePage = () => {
           autoPlay
           playsInline
           muted
-          style={{ width: '100%', height: 'auto', display: (loading || error || !iaModelsLoaded || !faceMatcher) ? 'none' : 'block', verticalAlign: 'middle', transform: 'scaleX(-1)' }}
+          style={{ width: '100%', height: 'auto', display: (loading || error || !iaModelsLoaded || !faceMatcher) ? 'none' : 'block', verticalAlign: 'middle', transform: isFrontCamera ? 'scaleX(-1)' : 'none' }}
           onCanPlay={() => setLoading(false)}
         />
         <canvas ref={canvasRef} style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} />

--- a/frontend/src/pages/StudentProfilePage.jsx
+++ b/frontend/src/pages/StudentProfilePage.jsx
@@ -457,6 +457,8 @@ const StudentProfilePage = () => {
       3: '/assets/guide-right.png',
     };
 
+    const isFrontCamera = videoDevices[activeDeviceIndex]?.label.toLowerCase().includes('front');
+
     return (
       <div className="modal-overlay">
         <div className="modal-content" style={{textAlign: 'center'}}>
@@ -471,7 +473,7 @@ const StudentProfilePage = () => {
               height="360"
               style={{
                 borderRadius: '8px',
-                transform: 'scaleX(-1)',
+                transform: isFrontCamera ? 'scaleX(-1)' : 'none',
                 display: captureStep <= 3 ? 'block' : 'none'
               }}
             ></video>


### PR DESCRIPTION
This commit updates the camera views in both `StudentProfilePage` and `CameraAttendancePage` to be more intelligent.

The "mirror effect" (`transform: 'scaleX(-1)'`) is now only applied when the active video device is a front-facing camera. This is determined by checking if the device's label includes the word "front".

This provides a more natural experience for users, as the mirroring is helpful for selfie-style front cameras but disorienting for rear cameras.