### PR TITLE
fix(camera): Apply mirror effect only to front camera

### DIFF
--- a/frontend/src/pages/CameraAttendancePage.jsx
+++ b/frontend/src/pages/CameraAttendancePage.jsx
@@ -120,11 +120,20 @@ const CameraAttendancePage = () => {
 
   useEffect(() => {
     startCamera();
+
+    // --- AÑADIR ESTA FUNCIÓN DE LIMPIEZA ---
     return () => {
       if (videoRef.current && videoRef.current.srcObject) {
-        videoRef.current.srcObject.getTracks().forEach(track => track.stop());
+        const stream = videoRef.current.srcObject;
+        const tracks = stream.getTracks();
+
+        tracks.forEach(track => {
+          track.stop();
+        });
+        videoRef.current.srcObject = null;
       }
     };
+    // -----------------------------------------
   }, [startCamera, activeDeviceIndex]);
 
   const intervalRef = useRef(null);


### PR DESCRIPTION
This commit updates the camera views in both `StudentProfilePage` and `CameraAttendancePage` to be more intelligent.

The "mirror effect" (`transform: 'scaleX(-1)'`) is now only applied when the active video device is a front-facing camera. This is determined by checking if the device's label includes the word "front".

This provides a more natural experience for users, as the mirroring is helpful for selfie-style front cameras but disorienting for rear cameras.