### PR TITLE
feat: Replicate face registration in teacher's detailed edit view

### DIFF
--- a/backend/routes/studentAdminRoutes.js
+++ b/backend/routes/studentAdminRoutes.js
@@ -248,4 +248,38 @@ router.put('/:studentId/edit-full', async (req, res) => {
 });
 
 
+/**
+ * @route   POST /api/admin/students/:studentId/register-face
+ * @desc    Registrar o actualizar los descriptores faciales de un estudiante
+ * @access  Private (Teacher)
+ */
+router.post('/:studentId/register-face', async (req, res) => {
+  const { studentId } = req.params;
+  const { descriptors } = req.body;
+
+  if (!descriptors || !Array.isArray(descriptors) || descriptors.length === 0) {
+    return res.status(400).json({ message: 'Se requiere un array de descriptores faciales.' });
+  }
+
+  try {
+    // Convertir el array de arrays a un formato JSON string para guardarlo en la BD.
+    const descriptorsJson = JSON.stringify(descriptors);
+
+    const updateResult = await pool.query(
+      'UPDATE students SET face_descriptors = $1 WHERE id = $2 RETURNING id',
+      [descriptorsJson, studentId]
+    );
+
+    if (updateResult.rows.length === 0) {
+      return res.status(404).json({ message: 'Estudiante no encontrado.' });
+    }
+
+    res.json({ message: 'Registro facial completado exitosamente.' });
+  } catch (err) {
+    console.error('Error saving face descriptors for student by admin:', err);
+    res.status(500).json({ message: 'Error interno del servidor al guardar el registro facial.' });
+  }
+});
+
+
 module.exports = router;

--- a/frontend/src/components/FaceRegistration.jsx
+++ b/frontend/src/components/FaceRegistration.jsx
@@ -1,0 +1,253 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import axios from 'axios';
+import * as faceapi from 'face-api.js';
+import { API_BASE_URL } from '../config';
+import Spinner from './Spinner';
+
+const FaceRegistration = ({ studentId, userType = 'student', onClose, isOpen }) => {
+  const [faceApiLoaded, setFaceApiLoaded] = useState(false);
+  const [isCapturing, setIsCapturing] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [captureStep, setCaptureStep] = useState(0); // 0: inactivo, 1: frente, 2: izq, 3: der, 4: preview
+  const [collectedDescriptors, setCollectedDescriptors] = useState([]);
+  const [videoDevices, setVideoDevices] = useState([]);
+  const [activeDeviceIndex, setActiveDeviceIndex] = useState(0);
+
+  const videoRef = useRef();
+  const canvasRef = useRef();
+
+  const getToken = useCallback(() => {
+    return userType === 'teacher' ? localStorage.getItem('teacherToken') : localStorage.getItem('studentToken');
+  }, [userType]);
+
+  // Cargar los modelos de face-api.js
+  useEffect(() => {
+    const loadModels = async () => {
+      const MODEL_URL = '/models'; // Asume que los modelos están en public/models
+      try {
+        await Promise.all([
+          faceapi.nets.tinyFaceDetector.loadFromUri(MODEL_URL),
+          faceapi.nets.faceLandmark68Net.loadFromUri(MODEL_URL),
+          faceapi.nets.faceRecognitionNet.loadFromUri(MODEL_URL),
+        ]);
+        setFaceApiLoaded(true);
+      } catch (error) {
+        console.error("Error loading face-api models", error);
+        setError("No se pudieron cargar las herramientas de IA. Inténtalo de nuevo.");
+      }
+    };
+    loadModels();
+  }, []);
+
+  const startVideo = useCallback(async () => {
+    if (videoRef.current && videoRef.current.srcObject) {
+      videoRef.current.srcObject.getTracks().forEach(track => track.stop());
+    }
+
+    let constraints = { video: true };
+    if (videoDevices.length > 0) {
+      constraints.video = { deviceId: videoDevices[activeDeviceIndex].deviceId };
+    }
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia(constraints);
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+      }
+      if (videoDevices.length === 0) {
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        const cameras = devices.filter(device => device.kind === 'videoinput');
+        setVideoDevices(cameras);
+      }
+    } catch (err) {
+      console.error("Error accessing camera:", err);
+      setError("No se pudo acceder a la cámara. Revisa los permisos en tu navegador.");
+    }
+  }, [videoDevices, activeDeviceIndex]);
+
+  useEffect(() => {
+    if (isOpen) {
+        // Reset state when modal is opened
+        setError('');
+        setSuccess('');
+        setVideoDevices([]);
+        setActiveDeviceIndex(0);
+        setCaptureStep(1);
+        setCollectedDescriptors([]);
+        startVideo();
+    }
+
+    return () => {
+      if (videoRef.current && videoRef.current.srcObject) {
+        videoRef.current.srcObject.getTracks().forEach(track => track.stop());
+      }
+    };
+  }, [isOpen, activeDeviceIndex, startVideo]);
+
+
+  const handleCameraChange = () => {
+    setActiveDeviceIndex(prevIndex => (prevIndex + 1) % videoDevices.length);
+  };
+
+  const handleRestartCapture = () => {
+    setCollectedDescriptors([]);
+    setCaptureStep(1);
+    setError('');
+    setSuccess('');
+    startVideo();
+  };
+
+  const handleCapture = async () => {
+    if (!videoRef.current) return;
+    setIsCapturing(true);
+    setError('');
+
+    const detections = await faceapi.detectSingleFace(videoRef.current, new faceapi.TinyFaceDetectorOptions())
+      .withFaceLandmarks()
+      .withFaceDescriptor();
+
+    if (!detections) {
+      setError("No se detectó rostro. Inténtalo de nuevo.");
+      setIsCapturing(false);
+      return;
+    }
+
+    const newDescriptors = [...collectedDescriptors, Array.from(detections.descriptor)];
+    setCollectedDescriptors(newDescriptors);
+
+    if (captureStep < 3) {
+      setCaptureStep(captureStep + 1);
+    } else {
+      if (videoRef.current && videoRef.current.srcObject) {
+        videoRef.current.srcObject.getTracks().forEach(track => track.stop());
+      }
+      setCaptureStep(4);
+    }
+    setIsCapturing(false);
+  };
+
+  const handleSaveFace = async () => {
+    if (collectedDescriptors.length < 3) {
+      setError("No se han completado las 3 capturas necesarias.");
+      return;
+    }
+    setIsCapturing(true);
+    setError('');
+    setSuccess('');
+
+    const token = getToken();
+    let url = '';
+    if (userType === 'teacher') {
+        url = `${API_BASE_URL}/admin/students/${studentId}/register-face`;
+    } else {
+        url = `${API_BASE_URL}/student/register-face`;
+    }
+
+    try {
+      await axios.post(url, { descriptors: collectedDescriptors }, { headers: { 'x-auth-token': token } });
+      setSuccess("¡Rostros registrados exitosamente!");
+      setTimeout(onClose, 2000);
+    } catch (err) {
+      console.error("Error saving face descriptors:", err);
+      setError(err.response?.data?.message || "Error al guardar los rostros en el servidor.");
+    } finally {
+      setIsCapturing(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const instructions = {
+    1: "Paso 1 de 3: Mira directamente a la cámara.",
+    2: "Paso 2 de 3: Gira tu rostro ligeramente a la izquierda.",
+    3: "Paso 3 de 3: Gira tu rostro ligeramente a la derecha.",
+    4: "¡Capturas completadas! Revisa y guarda."
+  };
+
+  const guideImages = {
+    1: '/assets/guide-front.png',
+    2: '/assets/guide-left.png',
+    3: '/assets/guide-right.png',
+  };
+
+  const isFrontCamera = videoDevices[activeDeviceIndex]?.label.toLowerCase().includes('front');
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-content" style={{textAlign: 'center', width: '90%', maxWidth: '500px'}}>
+        <h3>{instructions[captureStep]}</h3>
+        <p>Asegúrate de que tu rostro esté bien iluminado y centrado.</p>
+        <div style={{ position: 'relative', width: '100%', paddingTop: '75%', backgroundColor: '#111', borderRadius: '8px', overflow: 'hidden' }}>
+          <video
+            ref={videoRef}
+            autoPlay
+            muted
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              height: '100%',
+              objectFit: 'cover',
+              borderRadius: '8px',
+              transform: isFrontCamera ? 'scaleX(-1)' : 'none',
+              display: captureStep <= 3 ? 'block' : 'none'
+            }}
+          ></video>
+          {captureStep <= 3 && (
+            <img
+              src={guideImages[captureStep]}
+              alt="Guía Facial"
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: '100%',
+                opacity: 0.6,
+                objectFit: 'contain',
+                pointerEvents: 'none'
+              }}
+            />
+          )}
+           {captureStep > 3 && <div style={{width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'white'}}>Video pausado.</div>}
+        </div>
+        <div style={{marginTop: '1rem', minHeight: '2.5rem'}}>
+          {error && <p style={{color: 'red', marginBottom: '1rem'}}>{error}</p>}
+          {success && <p style={{color: 'green', marginBottom: '1rem'}}>{success}</p>}
+          {captureStep <= 3 && <p>Capturas realizadas: {collectedDescriptors.length} de 3</p>}
+        </div>
+
+        {videoDevices.length > 1 && captureStep <= 3 && (
+          <div style={{ margin: '1rem 0' }}>
+            <button onClick={handleCameraChange} className="btn-secondary">
+              Cambiar Cámara 🔄
+            </button>
+          </div>
+        )}
+
+        <div className="modal-actions" style={{display: 'flex', gap: '1rem', justifyContent: 'center', flexWrap: 'wrap'}}>
+          {captureStep <= 3 && (
+            <>
+              <button onClick={onClose} className="btn-secondary" disabled={isCapturing}>Cancelar</button>
+              <button onClick={handleCapture} className="btn-primary" disabled={isCapturing || !faceApiLoaded}>
+                {isCapturing ? <><Spinner size="20px" color="white" /> Capturando...</> : (faceApiLoaded ? `Capturar Foto ${captureStep}`: 'Cargando IA...')}
+              </button>
+            </>
+          )}
+          {captureStep > 3 && (
+            <>
+              <button onClick={handleRestartCapture} className="btn-secondary" disabled={isCapturing}>Empezar de Nuevo</button>
+              <button onClick={handleSaveFace} className="btn-primary" disabled={isCapturing}>
+                {isCapturing ? <><Spinner size="20px" color="white" /> Guardando...</> : 'Guardar Registros'}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FaceRegistration;

--- a/frontend/src/pages/TeacherDatabasePage.jsx
+++ b/frontend/src/pages/TeacherDatabasePage.jsx
@@ -2,10 +2,13 @@ import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
 import { API_BASE_URL } from '../config'; // Corregir la ruta de importación
+import FaceRegistration from '../components/FaceRegistration'; // Importar el nuevo componente
 
 // Iconos
 const EditIcon = () => <svg className="icon" viewBox="0 0 20 20" fill="currentColor" width="16" height="16"><path d="M5.433 13.917l1.262-3.155A4 4 0 017.58 9.42l6.92-6.918a2.121 2.121 0 013 3l-6.92 6.918c-.383.383-.84.685-1.343.886l-3.154 1.262a.5.5 0 01-.65-.65z" /><path d="M3.5 5.75c0-.69.56-1.25 1.25-1.25H10A.75.75 0 0010 3H4.75A2.75 2.75 0 002 5.75v9.5A2.75 2.75 0 004.75 18h9.5A2.75 2.75 0 0017 15.25V10a.75.75 0 00-1.5 0v5.25c0 .69-.56 1.25-1.25 1.25h-9.5c-.69 0-1.25-.56-1.25-1.25v-9.5z" /></svg>;
 const SaveIcon = () => <svg className="icon" viewBox="0 0 20 20" fill="currentColor" width="16" height="16" style={{verticalAlign: 'middle', marginRight: '0.5em'}}><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm.75-11.25a.75.75 0 00-1.5 0v2.5h-2.5a.75.75 0 000 1.5h2.5v2.5a.75.75 0 001.5 0v-2.5h2.5a.75.75 0 000-1.5h-2.5v-2.5z" clipRule="evenodd" /></svg>;
+const FaceIcon = () => <svg className="icon" viewBox="0 0 20 20" fill="currentColor" width="16" height="16" style={{ verticalAlign: 'middle', marginRight: '0.5em' }}><path d="M10 9a3 3 0 100-6 3 3 0 000 6z" /><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM4.056 13.878a6 6 0 118.944 0A8.002 8.002 0 0010 16a8.002 8.002 0 00-5.944-2.122z" clipRule="evenodd" /></svg>;
+
 
 // Definir la constante API_URL_BASE_FOR_STUDENTS fuera del componente, usando la importación.
 const API_URL_BASE_FOR_STUDENTS = `${API_BASE_URL}/admin/students`;
@@ -20,6 +23,10 @@ const TeacherDatabasePage = () => {
   const [showEditFullModal, setShowEditFullModal] = useState(false);
   const [currentStudentToEdit, setCurrentStudentToEdit] = useState(null);
   const [editFormData, setEditFormData] = useState({});
+
+  const [showFaceRegistrationModal, setShowFaceRegistrationModal] = useState(false);
+  const [studentForFaceRegistration, setStudentForFaceRegistration] = useState(null);
+
 
   // Corrección: La importación dinámica no es ideal dentro del cuerpo del componente para una constante.
   // Se asume que config.js exporta API_BASE_URL directamente.
@@ -77,6 +84,16 @@ const TeacherDatabasePage = () => {
   };
 
   const handleCloseEditFullModal = () => { setShowEditFullModal(false); setCurrentStudentToEdit(null); setEditFormData({}); };
+
+  const handleOpenFaceRegistrationModal = (student) => {
+    setStudentForFaceRegistration(student);
+    setShowFaceRegistrationModal(true);
+  };
+
+  const handleCloseFaceRegistrationModal = () => {
+    setShowFaceRegistrationModal(false);
+    setStudentForFaceRegistration(null);
+  };
 
   const handleSubmitEditFull = async (e) => {
     e.preventDefault();
@@ -198,13 +215,29 @@ const TeacherDatabasePage = () => {
                   </label>
                 </div>
               </div>
-              <div className="modal-actions">
-                <button type="button" onClick={handleCloseEditFullModal} className="btn-secondary">Cancelar</button>
-                <button type="submit" className="btn-primary"><SaveIcon /> Guardar Cambios</button>
+              <div className="modal-actions" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', marginTop: '1.5rem' }}>
+                <div>
+                  <button type="button" onClick={() => handleOpenFaceRegistrationModal(currentStudentToEdit)} className="btn-action">
+                    <FaceIcon /> Registrar Rostro
+                  </button>
+                </div>
+                <div style={{ display: 'flex', gap: '1rem' }}>
+                  <button type="button" onClick={handleCloseEditFullModal} className="btn-secondary">Cancelar</button>
+                  <button type="submit" className="btn-primary"><SaveIcon /> Guardar Cambios</button>
+                </div>
               </div>
             </form>
           </div>
         </div>
+      )}
+
+      {showFaceRegistrationModal && studentForFaceRegistration && (
+        <FaceRegistration
+          studentId={studentForFaceRegistration.id}
+          userType="teacher"
+          isOpen={showFaceRegistrationModal}
+          onClose={handleCloseFaceRegistrationModal}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
This commit introduces the functionality for teachers to register a student's face from the "Edit Detailed" view in the student database.

Key changes:
- A reusable `FaceRegistration.jsx` component has been created by extracting the logic from `StudentProfilePage.jsx`.
- `StudentProfilePage.jsx` has been refactored to use the new `FaceRegistration` component.
- `TeacherDatabasePage.jsx` now includes a "Register Face" button in the "Edit Detailed" modal, which opens the `FaceRegistration` component.
- A new backend endpoint `POST /api/admin/students/:studentId/register-face` has been added to allow teachers to save a student's face descriptors.