### PR TITLE
fix: Correct column name for face descriptor in admin route

### DIFF
--- a/backend/routes/studentAdminRoutes.js
+++ b/backend/routes/studentAdminRoutes.js
@@ -266,7 +266,7 @@ router.post('/:studentId/register-face', async (req, res) => {
     const descriptorsJson = JSON.stringify(descriptors);
 
     const updateResult = await pool.query(
-      'UPDATE students SET face_descriptors = $1 WHERE id = $2 RETURNING id',
+      'UPDATE students SET face_descriptor = $1 WHERE id = $2 RETURNING id',
       [descriptorsJson, studentId]
     );
 


### PR DESCRIPTION
This commit fixes a bug that caused an "Internal server error" when a teacher tried to save a student's facial registration data. The error was due to a typo in the database column name in the backend route.

The `studentAdminRoutes.js` file was using `face_descriptors` (plural) instead of the correct `face_descriptor` (singular) when updating the student's record. This commit corrects the column name in the SQL query, aligning it with the existing implementation and the database schema.