### PR TITLE
feat: Integrate global group filter across all teacher pages

### DIFF
--- a/backend/routes/attendanceRoutes.js
+++ b/backend/routes/attendanceRoutes.js
@@ -265,7 +265,8 @@ router.post('/close', authMiddleware, async (req, res) => {
  * @access  Private (Teacher)
  */
 router.get('/status/:date', authMiddleware, async (req, res) => {
-  const { date } = req.params; // Fecha en formato 'YYYY-MM-DD'
+  const { date } = req.params;
+  const { group_id } = req.query;
 
   if (!date) {
     return res.status(400).json({ message: 'El parámetro de fecha es requerido.' });
@@ -274,24 +275,38 @@ router.get('/status/:date', authMiddleware, async (req, res) => {
   try {
     const client = await pool.connect();
     try {
-      // Obtener registros de asistencia
-      const attendanceResult = await client.query(
-        `SELECT ar.student_id, s.full_name, s.nickname, ar.status, ar.points_earned, ar.base_attendance_points, ar.notes, ar.recorded_at
-         FROM attendance_records ar
-         JOIN students s ON ar.student_id = s.id
-         WHERE ar.attendance_date = $1
-         ORDER BY s.full_name`,
-        [date]
-      );
+      // Build attendance query
+      let attendanceQuery = `
+        SELECT ar.student_id, s.full_name, s.nickname, ar.status, ar.points_earned, ar.base_attendance_points, ar.notes, ar.recorded_at
+        FROM attendance_records ar
+        JOIN students s ON ar.student_id = s.id
+      `;
+      const attendanceConditions = ['ar.attendance_date = $1'];
+      const queryParams = [date];
 
-      // Obtener el bono madrugador si existe para esa fecha
-      const bonusResult = await client.query(
-        `SELECT dbl.student_id, s.full_name AS bonus_student_name, dbl.points_awarded
-         FROM daily_bonus_log dbl
-         JOIN students s ON dbl.student_id = s.id
-         WHERE dbl.bonus_date = $1`,
-        [date]
-      );
+      if (group_id && group_id !== 'all') {
+        queryParams.push(group_id);
+        attendanceConditions.push(`s.group_id = $${queryParams.length}`);
+      }
+      attendanceQuery += ` WHERE ${attendanceConditions.join(' AND ')} ORDER BY s.full_name`;
+
+      const attendanceResult = await client.query(attendanceQuery, queryParams);
+
+      // Build bonus query (bonus is global, but we check if the awarded student is in the filtered group)
+      let bonusQuery = `
+        SELECT dbl.student_id, s.full_name AS bonus_student_name, dbl.points_awarded
+        FROM daily_bonus_log dbl
+        JOIN students s ON dbl.student_id = s.id
+        WHERE dbl.bonus_date = $1
+      `;
+      const bonusParams = [date];
+
+      if (group_id && group_id !== 'all') {
+        bonusQuery += ` AND s.group_id = $2`;
+        bonusParams.push(group_id);
+      }
+
+      const bonusResult = await client.query(bonusQuery, bonusParams);
 
       res.json({
         attendance_records: attendanceResult.rows,

--- a/backend/routes/reportRoutes.js
+++ b/backend/routes/reportRoutes.js
@@ -99,7 +99,7 @@ router.get('/student-summary', async (req, res) => {
  * @query   date=YYYY-MM-DD
  */
 router.get('/daily-summary', async (req, res) => {
-  const { date } = req.query; // date en formato YYYY-MM-DD
+  const { date, group_id } = req.query;
 
   if (!date) {
     return res.status(400).json({ message: 'date (YYYY-MM-DD) es requerido.' });
@@ -158,11 +158,17 @@ router.get('/daily-summary', async (req, res) => {
       LEFT JOIN student_attendance_points sap ON s.id = sap.student_id
       LEFT JOIN student_bonus_points sbp ON s.id = sbp.student_id
       LEFT JOIN aggregated_score_points asp ON s.id = asp.student_id
-      WHERE s.is_active = true -- Añadido para incluir solo estudiantes activos
+      WHERE s.is_active = true
+      ${group_id && group_id !== 'all' ? 'AND s.group_id = $2' : ''}
       ORDER BY s.full_name;
     `;
 
-    const summaryResult = await client.query(summaryQuery, [date]);
+    const queryParams = [date];
+    if (group_id && group_id !== 'all') {
+      queryParams.push(group_id);
+    }
+
+    const summaryResult = await client.query(summaryQuery, queryParams);
 
     res.json({
       date,
@@ -184,7 +190,7 @@ router.get('/daily-summary', async (req, res) => {
  * @query   month=YYYY-MM
  */
 router.get('/monthly-ranking', async (req, res) => {
-  const { month } = req.query; // month en formato YYYY-MM
+  const { month, group_id } = req.query;
 
   if (!month) {
     return res.status(400).json({ message: 'month (YYYY-MM) es requerido.' });
@@ -247,10 +253,15 @@ router.get('/monthly-ranking', async (req, res) => {
             LEFT JOIN student_bonus_points_prev sbp ON s.id = sbp.student_id
             LEFT JOIN student_score_records_points_prev ssrp ON s.id = ssrp.student_id
             WHERE s.is_active = true
+            ${group_id && group_id !== 'all' ? `AND s.group_id = $2` : ''}
             ORDER BY grand_total_points DESC, s.full_name ASC
             LIMIT 10;
         `;
-        const prevRankingResult = await client.query(prevRankingQuery, [prevMonthString]);
+        const prevRankingParams = [prevMonthString];
+        if (group_id && group_id !== 'all') {
+            prevRankingParams.push(group_id);
+        }
+        const prevRankingResult = await client.query(prevRankingQuery, prevRankingParams);
         // Solo asignar IDs para el bono si hay resultados y el puntaje máximo del mes anterior es > 0
         if (prevRankingResult.rows.length > 0 && prevRankingResult.rows[0].grand_total_points > 0) {
             top10PreviousMonthIDs = prevRankingResult.rows.map(r => r.student_id);
@@ -308,10 +319,15 @@ router.get('/monthly-ranking', async (req, res) => {
       LEFT JOIN student_bonus_points sbp ON s.id = sbp.student_id
       LEFT JOIN student_score_records_points ssrp ON s.id = ssrp.student_id
       WHERE s.is_active = true
+      ${group_id && group_id !== 'all' ? `AND s.group_id = $3` : ''}
       ORDER BY grand_total_points DESC, s.full_name ASC;
     `;
 
-    const currentRankingResult = await client.query(currentRankingQuery, [month, top10PreviousMonthIDs]);
+    const currentRankingParams = [month, top10PreviousMonthIDs];
+    if (group_id && group_id !== 'all') {
+        currentRankingParams.push(group_id);
+    }
+    const currentRankingResult = await client.query(currentRankingQuery, currentRankingParams);
 
     res.json({
       month,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import './App.css';
 
-import { GroupProvider } from './context/GroupContext';
+import GroupProvider from './context/GroupContext';
 import TeacherLayout from './layouts/TeacherLayout';
 
 import TeacherLoginPage from './pages/TeacherLoginPage';

--- a/frontend/src/context/GroupContext.jsx
+++ b/frontend/src/context/GroupContext.jsx
@@ -1,10 +1,8 @@
-import React, { createContext, useState, useContext } from 'react';
+import React, { createContext, useState } from 'react';
 
-const GroupContext = createContext();
+export const GroupContext = createContext();
 
-export const useGroup = () => useContext(GroupContext);
-
-export const GroupProvider = ({ children }) => {
+const GroupProvider = ({ children }) => {
     const [selectedGroupId, setSelectedGroupId] = useState('all'); // 'all' o un ID de grupo
 
     const value = {
@@ -18,3 +16,5 @@ export const GroupProvider = ({ children }) => {
         </GroupContext.Provider>
     );
 };
+
+export default GroupProvider;

--- a/frontend/src/layouts/TeacherLayout.jsx
+++ b/frontend/src/layouts/TeacherLayout.jsx
@@ -1,13 +1,13 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useContext } from 'react';
 import { Outlet } from 'react-router-dom';
 import axios from 'axios';
-import { useGroup } from '../context/GroupContext';
+import { GroupContext } from '../context/GroupContext';
 import { API_BASE_URL } from '../config';
 import toast from 'react-hot-toast';
 
 const TeacherLayout = () => {
     const [groups, setGroups] = useState([]);
-    const { selectedGroupId, setSelectedGroupId } = useGroup();
+    const { selectedGroupId, setSelectedGroupId } = useContext(GroupContext);
     const getToken = useCallback(() => localStorage.getItem('teacherToken'), []);
 
     useEffect(() => {

--- a/frontend/src/pages/StudentManagementPage.jsx
+++ b/frontend/src/pages/StudentManagementPage.jsx
@@ -2,33 +2,10 @@ import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
 import { API_BASE_URL } from '../config';
-import { useGroup } from '../context/GroupContext';
 import FaceRegistration from '../components/FaceRegistration';
 import ConfirmationModal from '../components/ConfirmationModal';
 import Spinner from '../components/Spinner';
 import toast from 'react-hot-toast';
-
-// Simple CSS-in-JS for tabs
-const styles = {
-  tabs: {
-    display: 'flex',
-    borderBottom: '1px solid #ccc',
-    marginBottom: '1rem',
-  },
-  tabButton: {
-    padding: '10px 20px',
-    cursor: 'pointer',
-    border: 'none',
-    background: 'none',
-    borderBottom: '2px solid transparent',
-    marginBottom: '-1px',
-    fontSize: '1rem',
-  },
-  activeTab: {
-    borderBottom: '2px solid var(--primary-color-teacher)',
-    fontWeight: 'bold',
-  }
-};
 
 // Iconos
 const AddIcon = () => <svg className="icon" viewBox="0 0 20 20" fill="currentColor" width="16" height="16"><path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z" /></svg>;

--- a/frontend/src/pages/TeacherAttendancePage.jsx
+++ b/frontend/src/pages/TeacherAttendancePage.jsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useContext } from 'react';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
+import { GroupContext } from '../context/GroupContext';
 import { getCurrentPeruDateTimeObject, getTodayPeruDateString } from "../utils/dateUtils";
 import { API_BASE_URL } from "../config";
 import Spinner from '../components/Spinner';
@@ -39,11 +40,45 @@ const TeacherAttendancePage = ({ selectedDate: historicDateProp }) => {
   const [isSavingSpecificAttendance, setIsSavingSpecificAttendance] = useState(false);
 
   const [dateForOperations, setDateForOperations] = useState(historicDateProp || getTodayPeruDateString());
+  const { selectedGroupId } = useContext(GroupContext);
 
   useEffect(() => { const newDate = historicDateProp || getTodayPeruDateString(); setDateForOperations(newDate); setDailyStatus({ attendance_records: [], bonus_awarded_today: null }); setAttendanceData({}); setSelectedStudentForBonus(''); }, [historicDateProp, getTodayPeruDateString]); // Añadido getTodayPeruDateString a dependencias
   const getToken = useCallback(() => localStorage.getItem('teacherToken'), []);
 
-  useEffect(() => { const fetchData = async () => { setLoading(true); setError(null); try { const token = getToken(); const headers = { 'x-auth-token': token }; const studentsResponse = await axios.get(`${API_BASE_URL}/admin/students?active=true`, { headers }); setAllStudents(studentsResponse.data); setStudents(studentsResponse.data); const dailyStatusResponse = await axios.get(`${API_BASE_URL}/attendance/status/${dateForOperations}?t=${new Date().getTime()}`, { headers }); setDailyStatus(dailyStatusResponse.data); const initialAttendance = {}; dailyStatusResponse.data.attendance_records.forEach(record => { initialAttendance[record.student_id] = { status: record.status, notes: record.notes || '', is_synced: true }; }); setAttendanceData(initialAttendance); } catch (err) { console.error(`Error fetching initial data for date ${dateForOperations}:`, err); setError(err.response?.data?.message || err.message || 'Error al cargar datos iniciales.'); } finally { setLoading(false); } }; fetchData(); }, [getToken, dateForOperations, API_BASE_URL]);
+  useEffect(() => {
+    const fetchData = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const token = getToken();
+            const headers = { 'x-auth-token': token };
+
+            const studentParams = new URLSearchParams({ active: 'true' });
+            if (selectedGroupId && selectedGroupId !== 'all') {
+                studentParams.append('group_id', selectedGroupId);
+            }
+
+            const studentsResponse = await axios.get(`${API_BASE_URL}/admin/students`, { headers, params: studentParams });
+            setAllStudents(studentsResponse.data);
+            setStudents(studentsResponse.data);
+
+            const dailyStatusResponse = await axios.get(`${API_BASE_URL}/attendance/status/${dateForOperations}?t=${new Date().getTime()}`, { headers });
+            setDailyStatus(dailyStatusResponse.data);
+
+            const initialAttendance = {};
+            dailyStatusResponse.data.attendance_records.forEach(record => {
+                initialAttendance[record.student_id] = { status: record.status, notes: record.notes || '', is_synced: true };
+            });
+            setAttendanceData(initialAttendance);
+        } catch (err) {
+            console.error(`Error fetching initial data for date ${dateForOperations}:`, err);
+            setError(err.response?.data?.message || err.message || 'Error al cargar datos iniciales.');
+        } finally {
+            setLoading(false);
+        }
+    };
+    fetchData();
+  }, [getToken, dateForOperations, selectedGroupId]);
   useEffect(() => { let timer; if (!historicDateProp) { timer = setInterval(() => setCurrentPeruDateTime(getCurrentPeruDateTimeObject()), 1000); } return () => { if (timer) clearInterval(timer); }; }, [historicDateProp]); // getCurrentPeruDateTimeObject es estable
   useEffect(() => { if (!searchTerm) { setStudents(allStudents); return; } const lowerSearchTerm = searchTerm.toLowerCase(); const filtered = allStudents.filter(student => student.full_name.toLowerCase().includes(lowerSearchTerm) || student.id.toLowerCase().includes(lowerSearchTerm)); setStudents(filtered); }, [searchTerm, allStudents]);
 

--- a/frontend/src/pages/TeacherRankingPage.jsx
+++ b/frontend/src/pages/TeacherRankingPage.jsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useContext } from 'react';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
+import { GroupContext } from '../context/GroupContext';
 import { API_BASE_URL } from '../config'; // Importar API_BASE_URL
 
 const TrophyIcon = () => <svg className="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="16" height="16"><path fillRule="evenodd" d="M15.28 4.72a.75.75 0 010 1.06l-2.5 2.5a.75.75 0 01-1.06 0l-1-1a.75.75 0 111.06-1.06l.47.47L14.22 4.72a.75.75 0 011.06 0zm-4.78 4.03a.75.75 0 01-1.06 0l-1-1a.75.75 0 111.06-1.06l.47.47 2.5-2.5a.75.75 0 011.06 1.06l-3 3.001zM5.78 8.72a.75.75 0 010-1.06l2.5-2.5a.75.75 0 011.06 0L11.28 7.1a.75.75 0 11-1.06 1.06l-.47-.47-2.5 2.5a.75.75 0 01-1.06 0zM2.5 13.25a.75.75 0 01.75-.75h13.5a.75.75 0 010 1.5H3.25a.75.75 0 01-.75-.75zM3 15.25a.75.75 0 01.75-.75h12.5a.75.75 0 010 1.5H3.75a.75.75 0 01-.75-.75zM2 18a.75.75 0 000 1.5h16a.75.75 0 000-1.5H2z" clipRule="evenodd" /></svg>;
@@ -10,8 +11,8 @@ const TeacherRankingPage = () => {
   const [rankingData, setRankingData] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const { selectedGroupId } = useContext(GroupContext);
 
-  // const API_URL = 'http://localhost:3001/api'; // Eliminar esta línea
   const getToken = useCallback(() => localStorage.getItem('teacherToken'), []);
 
   const fetchRanking = useCallback(async (monthToFetch) => {
@@ -19,16 +20,19 @@ const TeacherRankingPage = () => {
     setLoading(true); setError('');
     try {
       const token = getToken();
-      // Usar API_BASE_URL para construir la URL de la solicitud
+      const params = { month: monthToFetch };
+      if (selectedGroupId && selectedGroupId !== 'all') {
+        params.group_id = selectedGroupId;
+      }
       const response = await axios.get(`${API_BASE_URL}/reports/monthly-ranking`, {
-        params: { month: monthToFetch }, headers: { 'x-auth-token': token },
+        params, headers: { 'x-auth-token': token },
       });
       setRankingData(response.data.ranking || []);
     } catch (err) { console.error("Error fetching ranking:", err); setError(err.response?.data?.message || 'Error al cargar el ranking.'); setRankingData([]); }
     finally { setLoading(false); }
-  }, [getToken]); // Eliminar API_URL de las dependencias, API_BASE_URL es constante y no necesita estar aquí
+  }, [getToken, selectedGroupId]);
 
-  useEffect(() => { fetchRanking(selectedMonth); }, [fetchRanking, selectedMonth]);
+  useEffect(() => { fetchRanking(selectedMonth); }, [fetchRanking, selectedMonth, selectedGroupId]);
 
   const handleFetchRanking = () => { fetchRanking(selectedMonth); };
 

--- a/frontend/src/pages/TeacherScoresPage.jsx
+++ b/frontend/src/pages/TeacherScoresPage.jsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useContext } from 'react';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
+import { GroupContext } from '../context/GroupContext';
 import { getTodayPeruDateString as getTodayPeruDateStringForScores } from "../utils/dateUtils";
 import { API_BASE_URL } from "../config";
 import Spinner from '../components/Spinner';
@@ -31,36 +32,45 @@ const TeacherScoresPage = () => {
   const [personalPoints, setPersonalPoints] = useState('');
   const [personalSubCategory, setPersonalSubCategory] = useState('');
   const [personalNotes, setPersonalNotes] = useState('');
+  const { selectedGroupId } = useContext(GroupContext);
 
   const getToken = useCallback(() => localStorage.getItem('teacherToken'), []);
 
   const fetchAttendanceAndFilterStudents = useCallback(async (dateForFilter) => {
     if (!dateForFilter || allStudents.length === 0) {
-      setPresentStudents(allStudents.length > 0 ? allStudents : []);
-      setLoadingAttendance(false);
-      return;
+        setPresentStudents(allStudents.length > 0 ? allStudents : []);
+        setLoadingAttendance(false);
+        return;
     }
     setLoadingAttendance(true);
     setError('');
     try {
-      const token = getToken();
-      const response = await axios.get(`${API_BASE_URL}/attendance/status/${dateForFilter}`, { headers: { 'x-auth-token': token } });
-      const attendanceRecords = response.data.attendance_records || [];
-      const presentStudentIds = new Set(
-        attendanceRecords
-          .filter(record => record.status && !record.status.startsWith('AUSENCIA'))
-          .map(record => record.student_id)
-      );
-      const filtered = allStudents.filter(student => presentStudentIds.has(student.id));
-      setPresentStudents(filtered);
+        const token = getToken();
+        const params = new URLSearchParams();
+        if (selectedGroupId && selectedGroupId !== 'all') {
+            params.append('group_id', selectedGroupId);
+        }
+
+        const response = await axios.get(`${API_BASE_URL}/attendance/status/${dateForFilter}`, {
+            headers: { 'x-auth-token': token },
+            params
+        });
+        const attendanceRecords = response.data.attendance_records || [];
+        const presentStudentIds = new Set(
+            attendanceRecords
+                .filter(record => record.status && !record.status.startsWith('AUSENCIA'))
+                .map(record => record.student_id)
+        );
+        const filtered = allStudents.filter(student => presentStudentIds.has(student.id));
+        setPresentStudents(filtered);
     } catch (err) {
-      console.error(`Error fetching attendance for ${dateForFilter}:`, err);
-      setError(err.response?.data?.message || err.message || `Error al cargar asistencia para ${dateForFilter}.`);
-      setPresentStudents([]);
+        console.error(`Error fetching attendance for ${dateForFilter}:`, err);
+        setError(err.response?.data?.message || err.message || `Error al cargar asistencia para ${dateForFilter}.`);
+        setPresentStudents([]);
     } finally {
-      setLoadingAttendance(false);
+        setLoadingAttendance(false);
     }
-  }, [getToken, allStudents, API_BASE_URL]);
+  }, [getToken, allStudents, selectedGroupId]);
 
   // Carga inicial de todos los estudiantes
   useEffect(() => {
@@ -68,7 +78,14 @@ const TeacherScoresPage = () => {
       setLoadingStudents(true);
       try {
         const token = getToken();
-        const response = await axios.get(`${API_BASE_URL}/admin/students?active=true`, { headers: { 'x-auth-token': token } });
+        const params = new URLSearchParams({ active: 'true' });
+        if (selectedGroupId && selectedGroupId !== 'all') {
+            params.append('group_id', selectedGroupId);
+        }
+        const response = await axios.get(`${API_BASE_URL}/admin/students`, {
+            headers: { 'x-auth-token': token },
+            params
+        });
         setAllStudents(response.data);
       } catch (err) {
         console.error("Error fetching all students:", err);
@@ -78,7 +95,7 @@ const TeacherScoresPage = () => {
       }
     };
     fetchAllStudents();
-  }, [getToken, API_BASE_URL]);
+  }, [getToken, selectedGroupId]);
 
   // Efecto para obtener estudiantes presentes cuando cambia la fecha o la lista de todos los estudiantes
   useEffect(() => {

--- a/frontend/src/pages/TeacherSummaryPage.jsx
+++ b/frontend/src/pages/TeacherSummaryPage.jsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useContext } from 'react';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
+import { GroupContext } from '../context/GroupContext';
 import { API_BASE_URL } from '../config'; // Importar API_BASE_URL
 
 // Icono para el botón
@@ -17,21 +18,31 @@ const TeacherSummaryPage = () => {
   const [summaryData, setSummaryData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const { selectedGroupId } = useContext(GroupContext);
 
-  // const API_URL = 'http://localhost:3001/api'; // Eliminar esta línea
   const getToken = useCallback(() => localStorage.getItem('teacherToken'), []);
 
   useEffect(() => {
     const fetchStudents = async () => {
       try {
         const token = getToken();
-        // Usar API_BASE_URL para construir la URL de la solicitud
-        const response = await axios.get(`${API_BASE_URL}/admin/students?active=true`, { headers: { 'x-auth-token': token } });
+        const params = new URLSearchParams({ active: 'true' });
+        if (selectedGroupId && selectedGroupId !== 'all') {
+            params.append('group_id', selectedGroupId);
+        }
+        const response = await axios.get(`${API_BASE_URL}/admin/students`, {
+            headers: { 'x-auth-token': token },
+            params
+        });
         setStudents(response.data);
+        // If the currently selected student is not in the new list, reset it
+        if (selectedStudent && !response.data.some(s => s.id === selectedStudent)) {
+            setSelectedStudent('');
+        }
       } catch (err) { console.error("Error fetching students:", err); setError(err.response?.data?.message || 'Error al cargar estudiantes.'); }
     };
     fetchStudents();
-  }, [getToken]); // API_BASE_URL es constante global, no necesita ser dependencia
+  }, [getToken, selectedGroupId, selectedStudent]);
 
   const handleFetchSummary = async () => {
     setLoading(true); setError(''); setSummaryData(null);
@@ -44,8 +55,11 @@ const TeacherSummaryPage = () => {
         response = await axios.get(`${API_BASE_URL}/reports/student-summary`, { params: { studentId: selectedStudent, month: selectedMonth }, headers });
       } else {
         if (!selectedDate) { setError('Por favor, seleccione una fecha.'); setLoading(false); return; }
-        // Usar API_BASE_URL para construir la URL de la solicitud
-        response = await axios.get(`${API_BASE_URL}/reports/daily-summary`, { params: { date: selectedDate }, headers });
+        const params = { date: selectedDate };
+        if (selectedGroupId && selectedGroupId !== 'all') {
+            params.group_id = selectedGroupId;
+        }
+        response = await axios.get(`${API_BASE_URL}/reports/daily-summary`, { params, headers });
       }
       setSummaryData(response.data);
     } catch (err) { console.error("Error fetching summary:", err); setError(err.response?.data?.message || 'Error al cargar el resumen.'); }


### PR DESCRIPTION
This feature integrates the new global group filter with all relevant pages in the teacher's panel, including Attendance, Scores, Summary, and Ranking.

Key changes include:
- **Backend:**
  - Updated the attendance and reporting API endpoints to accept a `group_id` parameter and filter the results accordingly. This ensures that all data fetched is scoped to the selected group.

- **Frontend:**
  - Modified all relevant pages (`TeacherAttendancePage`, `TeacherScoresPage`, `TeacherSummaryPage`, `TeacherRankingPage`) to use the `useGroup` context.
  - The `selectedGroupId` is now passed as a parameter in all relevant API calls, ensuring the data displayed on each page reflects the filter's selection.
  - Fixed linter errors that arose during development.