### PR TITLE
fix: Add database schema migration to fix server startup error

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -41,6 +41,60 @@ app.use('/api/admin/settings', authMiddleware, adminSettingsRoutes); // <-- Mont
 app.use('/api/groups', authMiddleware, groupRoutes);
 app.use('/api/public', publicRoutes); // Rutas públicas (ej: /api/public/register)
 
+const ensureDatabaseSchema = async () => {
+    const client = await pool.connect();
+    try {
+        // 1. Check for 'groups' table
+        const tableCheck = await client.query(
+            "SELECT FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'groups'"
+        );
+
+        if (tableCheck.rows.length === 0) {
+            console.log("Schema migration needed: 'groups' table not found. Creating it...");
+            await client.query('BEGIN');
+            // Create groups table
+            await client.query(`
+                CREATE TABLE groups (
+                    group_id SERIAL PRIMARY KEY,
+                    name VARCHAR(100) NOT NULL,
+                    schedule_description TEXT
+                );
+            `);
+            // Populate groups table
+            await client.query(`
+                INSERT INTO groups (name, schedule_description) VALUES
+                ('Grupo 1', 'Jueves y Viernes - 5:00 PM'),
+                ('Grupo 2', 'Sábados - 3:00 PM y Martes - 5:00 PM'),
+                ('Grupo 3', 'Lunes y Miércoles - 5:00 PM');
+            `);
+            await client.query('COMMIT');
+            console.log("'groups' table created and populated successfully.");
+        }
+
+        // 2. Check for 'group_id' column in 'students' table
+        const columnCheck = await client.query(
+            "SELECT FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'students' AND column_name = 'group_id'"
+        );
+
+        if (columnCheck.rows.length === 0) {
+            console.log("Schema migration needed: 'group_id' column not found in 'students' table. Adding it...");
+            await client.query(`
+                ALTER TABLE students
+                ADD COLUMN group_id INTEGER REFERENCES groups(group_id) ON DELETE SET NULL;
+            `);
+            console.log("'group_id' column added to 'students' table successfully.");
+        }
+
+    } catch (err) {
+        console.error('!!! ERROR during database schema check/migration !!!');
+        console.error(err.stack);
+        await client.query('ROLLBACK');
+    } finally {
+        client.release();
+    }
+};
+
+
 // Iniciar servidor
 app.listen(port, async () => { // Convertir a función async
   console.log(`Backend server is running on port ${port}`);
@@ -51,6 +105,10 @@ app.listen(port, async () => { // Convertir a función async
     await client.query('SELECT NOW()'); // Prueba una consulta simple
     client.release();
     console.log('Database connection test query successful.');
+
+    // Ensure the database schema is up to date
+    await ensureDatabaseSchema();
+
   } catch (err) {
     console.error('!!! CRITICAL: Failed to connect to the database on startup !!!');
     console.error(err.stack);


### PR DESCRIPTION
This commit introduces a self-healing mechanism to the backend server startup process. It addresses a bug where the application would crash with a 500 error if the database schema was not up-to-date with the latest changes (i.e., missing the 'groups' table).

The `ensureDatabaseSchema` function in `server.js` now runs on startup and idempotently creates the `groups` table and adds the `group_id` column to the `students` table if they do not already exist.

This makes the application more resilient to schema drift, especially in environments where the `init.sql` script is only run once on initial creation.