### PR TITLE
feat: Add column selection to student export

### DIFF
--- a/backend/routes/reportRoutes.js
+++ b/backend/routes/reportRoutes.js
@@ -345,84 +345,96 @@ router.get('/monthly-ranking', async (req, res) => {
 
 /**
  * @route   GET /api/reports/export/students
- * @desc    Exportar lista de estudiantes en formato CSV.
+ * @desc    Exportar lista de estudiantes en formato CSV/XLS.
  * @access  Private (Teacher)
- * @query   mode=simple|full, group_id=<id>|all
+ * @query   columns=col1,col2,..., group_id=<id>|all
  */
 router.get('/export/students', async (req, res) => {
-  const { mode, group_id } = req.query;
+    const { columns, group_id } = req.query;
 
-  if (!mode || (mode !== 'simple' && mode !== 'full')) {
-    return res.status(400).json({ message: 'El parámetro "mode" es requerido y debe ser "simple" o "full".' });
-  }
-
-  let client;
-  try {
-    client = await pool.connect();
-
-    let query;
-    const queryParams = [];
-
-    // Campos para el modo simple
-    let selectFields = 's.id, s.full_name';
-    if (mode === 'full') {
-      // Todos los campos de students para el modo completo
-      selectFields = 's.*';
+    if (!columns) {
+        return res.status(400).json({ message: 'El parámetro "columns" es requerido.' });
     }
 
-    let fromClause = 'FROM students s';
-    let whereClause = 'WHERE s.is_active = true';
+    const requestedColumns = columns.split(',');
 
-    // Si se pide un reporte general (todos los grupos), añadir el nombre del grupo
-    if (!group_id || group_id === 'all') {
-      selectFields += ', g.name AS group_name';
-      fromClause += ' LEFT JOIN groups g ON s.group_id = g.group_id';
-    } else {
-      whereClause += ' AND s.group_id = $1';
-      queryParams.push(group_id);
+    // Whitelist de columnas para evitar inyección SQL
+    const allowedColumns = [
+        'id', 'full_name', 'nickname', 'age', 'birth_date', 'phone', 'email',
+        'guardian_full_name', 'guardian_relationship', 'guardian_phone',
+        'guardian_email', 'medical_conditions', 'comments',
+        'emergency_contact_name', 'emergency_contact_phone'
+    ];
+
+    const sanitizedColumns = requestedColumns.filter(col => allowedColumns.includes(col));
+
+    if (sanitizedColumns.length === 0 && !requestedColumns.includes('group_name')) {
+        return res.status(400).json({ message: 'Ninguna de las columnas solicitadas es válida.' });
     }
 
-    query = `SELECT ${selectFields} ${fromClause} ${whereClause} ORDER BY s.full_name;`;
+    let client;
+    try {
+        client = await pool.connect();
 
-    const { rows } = await client.query(query, queryParams);
+        const queryParams = [];
+        let fromClause = 'FROM students s';
+        let whereClause = 'WHERE s.is_active = true';
 
-    if (rows.length === 0) {
-      res.setHeader('Content-Type', 'text/csv');
-      res.setHeader('Content-Disposition', 'attachment; filename="students.csv"');
-      return res.status(200).send(''); // Enviar un CSV vacío si no hay datos
-    }
+        let selectFields = sanitizedColumns.map(col => `s.${col}`).join(', ');
 
-    // Convertir JSON a CSV manualmente
-    const headers = Object.keys(rows[0]);
-    const csvHeader = headers.join(',');
-
-    const csvRows = rows.map(row => {
-      return headers.map(header => {
-        let value = row[header];
-        // Si el valor es null o undefined, convertir a string vacío
-        if (value === null || typeof value === 'undefined') {
-          value = '';
+        // Manejo especial para la columna 'group_name'
+        if (requestedColumns.includes('group_name')) {
+            if (selectFields) selectFields += ', ';
+            selectFields += 'g.name AS group_name';
+            fromClause += ' LEFT JOIN groups g ON s.group_id = g.group_id';
         }
-        // Si el valor contiene comas, envolverlo en comillas dobles
-        if (typeof value === 'string' && value.includes(',')) {
-          return `"${value}"`;
+
+        if (group_id && group_id !== 'all') {
+            whereClause += ` AND s.group_id = $${queryParams.length + 1}`;
+            queryParams.push(group_id);
         }
-        return value;
-      }).join(',');
-    }).join('\n');
 
-    const csv = `${csvHeader}\n${csvRows}`;
+        const query = `SELECT ${selectFields || 's.id'} ${fromClause} ${whereClause} ORDER BY s.full_name;`;
 
-    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
-    res.setHeader('Content-Disposition', 'attachment; filename="students.csv"');
-    res.status(200).send(csv);
+        const { rows } = await client.query(query, queryParams);
 
-  } catch (err) {
-    console.error('Error en GET /api/reports/export/students:', err);
-    res.status(500).json({ message: 'Error interno del servidor al exportar los estudiantes.' });
-  } finally {
-    if (client) client.release();
-  }
+        if (rows.length === 0) {
+            res.setHeader('Content-Type', 'application/vnd.ms-excel');
+            const filename = `estudiantes-vacio-${new Date().toISOString().split('T')[0]}.xls`;
+            res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+            return res.status(200).send('');
+        }
+
+        const headers = Object.keys(rows[0]);
+        const csvHeader = headers.join('\t'); // Usar tab como separador para mejor compatibilidad con Excel
+
+        const csvRows = rows.map(row => {
+            return headers.map(header => {
+                let value = row[header];
+                if (value === null || typeof value === 'undefined') {
+                    value = '';
+                }
+                // Limpiar saltos de línea y otros caracteres que puedan romper el formato
+                if (typeof value === 'string') {
+                    value = value.replace(/(\r\n|\n|\r)/gm, " ").replace(/\t/g, " ");
+                }
+                return value;
+            }).join('\t');
+        }).join('\n');
+
+        const csv = `${csvHeader}\n${csvRows}`;
+
+        const filename = `estudiantes-${group_id || 'todos'}-${new Date().toISOString().split('T')[0]}.xls`;
+        res.setHeader('Content-Type', 'application/vnd.ms-excel; charset=utf-8');
+        res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+        res.status(200).send(Buffer.from(csv, 'utf-8'));
+
+    } catch (err) {
+        console.error('Error en GET /api/reports/export/students:', err);
+        res.status(500).json({ message: 'Error interno del servidor al exportar los estudiantes.' });
+    } finally {
+        if (client) client.release();
+    }
 });
 
 

--- a/frontend/src/pages/TeacherReportsPage.jsx
+++ b/frontend/src/pages/TeacherReportsPage.jsx
@@ -210,32 +210,69 @@ const StudentSummary = ({ getToken, selectedGroupId }) => {
 
 // --- Sub-component for Exporting Students ---
 const ExportStudents = ({ getToken, selectedGroupId }) => {
-    const [exportMode, setExportMode] = useState('simple');
+    const availableColumns = [
+        { key: 'id', label: 'ID' },
+        { key: 'full_name', label: 'Nombre Completo' },
+        { key: 'nickname', label: 'Apodo' },
+        { key: 'age', label: 'Edad' },
+        { key: 'birth_date', label: 'Fecha de Nacimiento' },
+        { key: 'phone', label: 'Celular' },
+        { key: 'email', label: 'Email' },
+        { key: 'guardian_full_name', label: 'Nombre del Apoderado' },
+        { key: 'guardian_relationship', label: 'Parentesco' },
+        { key: 'guardian_phone', label: 'Celular del Apoderado' },
+        { key: 'guardian_email', label: 'Email del Apoderado' },
+        { key: 'medical_conditions', label: 'Condiciones Médicas' },
+        { key: 'comments', label: 'Comentarios' },
+        { key: 'emergency_contact_name', label: 'Contacto de Emergencia' },
+        { key: 'emergency_contact_phone', label: 'Celular de Emergencia' },
+        { key: 'group_name', label: 'Grupo' },
+    ];
+
+    const [selectedColumns, setSelectedColumns] = useState(['id', 'full_name']);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState('');
-    const { groups } = useContext(GroupContext);
+
+    const handleColumnChange = (e) => {
+        const { value, checked } = e.target;
+        setSelectedColumns(prev =>
+            checked ? [...prev, value] : prev.filter(col => col !== value)
+        );
+    };
+
+    const handleSelectAll = (e) => {
+        if (e.target.checked) {
+            setSelectedColumns(availableColumns.map(col => col.key));
+        } else {
+            setSelectedColumns([]);
+        }
+    };
 
     const handleExport = async () => {
+        if (selectedColumns.length === 0) {
+            setError('Debes seleccionar al menos una columna para exportar.');
+            return;
+        }
+
         setLoading(true);
         setError('');
         try {
             const token = getToken();
             const params = {
-                mode: exportMode,
+                columns: selectedColumns.join(','),
                 group_id: selectedGroupId || 'all',
             };
 
             const response = await axios.get(`${API_BASE_URL}/reports/export/students`, {
                 params,
                 headers: { 'x-auth-token': token },
-                responseType: 'blob', // Importante para manejar la descarga de archivos
+                responseType: 'blob',
             });
 
-            // Crear un enlace para descargar el archivo
             const url = window.URL.createObjectURL(new Blob([response.data]));
             const link = document.createElement('a');
             link.href = url;
-            const filename = `estudiantes-${params.group_id}-${params.mode}-${new Date().toISOString().split('T')[0]}.csv`;
+            const filename = `estudiantes-${params.group_id}-${new Date().toISOString().split('T')[0]}.xls`;
             link.setAttribute('download', filename);
             document.body.appendChild(link);
             link.click();
@@ -243,8 +280,6 @@ const ExportStudents = ({ getToken, selectedGroupId }) => {
             window.URL.revokeObjectURL(url);
 
         } catch (err) {
-            // Como el responseType es 'blob', el error puede venir como blob también.
-            // Se necesita un FileReader para leer el mensaje de error del blob.
             if (err.response && err.response.data) {
                 const reader = new FileReader();
                 reader.onload = () => {
@@ -255,9 +290,7 @@ const ExportStudents = ({ getToken, selectedGroupId }) => {
                         setError('Error al procesar la respuesta del servidor.');
                     }
                 };
-                reader.onerror = () => {
-                    setError('No se pudo leer el error de la respuesta.');
-                };
+                reader.onerror = () => { setError('No se pudo leer el error de la respuesta.'); };
                 reader.readAsText(err.response.data);
             } else {
                 setError('Error de red o de servidor al intentar exportar.');
@@ -269,18 +302,37 @@ const ExportStudents = ({ getToken, selectedGroupId }) => {
 
     return (
         <div>
-            <div className="controls-bar" style={{ justifyContent: 'center', gap: '1rem', alignItems: 'flex-end' }}>
-                <div className="control-group">
-                    <label htmlFor="exportMode">Modo de Exportación:</label>
-                    <select id="exportMode" value={exportMode} onChange={(e) => setExportMode(e.target.value)}>
-                        <option value="simple">Simple (ID, Nombre)</option>
-                        <option value="full">Completo (Toda la info)</option>
-                    </select>
+            <div className="export-columns-container">
+                <h4>Selecciona las columnas a exportar:</h4>
+                <div className="checkbox-group select-all-group">
+                    <input
+                        type="checkbox"
+                        id="select-all"
+                        onChange={handleSelectAll}
+                        checked={selectedColumns.length === availableColumns.length}
+                    />
+                    <label htmlFor="select-all"><strong>Seleccionar Todo</strong></label>
                 </div>
-                {/* El filtro por grupo se gestiona globalmente a través de GroupContext, no se necesita un selector aquí */}
+                <div className="checkbox-grid">
+                    {availableColumns.map(col => (
+                        <div key={col.key} className="checkbox-group">
+                            <input
+                                type="checkbox"
+                                id={`col-${col.key}`}
+                                value={col.key}
+                                checked={selectedColumns.includes(col.key)}
+                                onChange={handleColumnChange}
+                            />
+                            <label htmlFor={`col-${col.key}`}>{col.label}</label>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            <div className="controls-bar" style={{ justifyContent: 'center', marginTop: '1.5rem' }}>
                 <button onClick={handleExport} disabled={loading} className="btn-action btn-export">
                     <svg className="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="16" height="16"><path d="M10 3a.75.75 0 01.75.75v10.638l3.96-4.155a.75.75 0 111.08 1.04l-5.25 5.5a.75.75 0 01-1.08 0l-5.25-5.5a.75.75 0 111.08-1.04l3.96 4.155V3.75A.75.75 0 0110 3z M3.75 16.5a.75.75 0 01.75-.75h10.5a.75.75 0 010 1.5H4.5a.75.75 0 01-.75-.75z" /></svg>
-                    {loading ? 'Exportando...' : 'Exportar a CSV'}
+                    {loading ? 'Exportando...' : 'Exportar a XLS'}
                 </button>
             </div>
             {error && <div className="error-message-page" style={{textAlign: 'center', marginTop: '1rem'}}>{error}</div>}


### PR DESCRIPTION
This commit refactors the student export functionality to allow users to select specific columns to export.

- **Frontend:**
  - The export UI in `TeacherReportsPage.jsx` now uses a list of checkboxes for column selection instead of a simple/full mode toggle.
  - A "Select All" checkbox is included for convenience.
  - The selected column keys are sent to the backend.

- **Backend:**
  - The `/api/reports/export/students` endpoint is updated to accept a `columns` parameter.
  - The endpoint now dynamically and safely builds the SQL query based on a whitelist of allowed columns.
  - The exported file is now served with a `.xls` extension and uses tab separation for better Excel compatibility.