### PR TITLE
feat: Add group management and enhance student export

### DIFF
--- a/backend/routes/groupRoutes.js
+++ b/backend/routes/groupRoutes.js
@@ -16,4 +16,75 @@ router.get('/', authMiddleware, async (req, res) => {
     }
 });
 
+// @route   POST /api/groups
+// @desc    Create a new group
+// @access  Private (Teacher)
+router.post('/', authMiddleware, async (req, res) => {
+    const { name, schedule_description } = req.body;
+    if (!name) {
+        return res.status(400).json({ message: 'El nombre del grupo es requerido.' });
+    }
+
+    try {
+        const { rows } = await pool.query(
+            'INSERT INTO groups (name, schedule_description) VALUES ($1, $2) RETURNING *',
+            [name, schedule_description || '']
+        );
+        res.status(201).json(rows[0]);
+    } catch (err) {
+        console.error('Error creating group:', err.message);
+        res.status(500).send('Server error');
+    }
+});
+
+// @route   PUT /api/groups/:id
+// @desc    Update a group
+// @access  Private (Teacher)
+router.put('/:id', authMiddleware, async (req, res) => {
+    const { id } = req.params;
+    const { name, schedule_description } = req.body;
+
+    if (!name) {
+        return res.status(400).json({ message: 'El nombre del grupo es requerido.' });
+    }
+
+    try {
+        const { rows } = await pool.query(
+            'UPDATE groups SET name = $1, schedule_description = $2 WHERE group_id = $3 RETURNING *',
+            [name, schedule_description || '', id]
+        );
+
+        if (rows.length === 0) {
+            return res.status(404).json({ message: 'Grupo no encontrado.' });
+        }
+
+        res.json(rows[0]);
+    } catch (err) {
+        console.error('Error updating group:', err.message);
+        res.status(500).send('Server error');
+    }
+});
+
+// @route   DELETE /api/groups/:id
+// @desc    Delete a group
+// @access  Private (Teacher)
+router.delete('/:id', authMiddleware, async (req, res) => {
+    const { id } = req.params;
+
+    try {
+        // La constraint ON DELETE SET NULL en la tabla students se encargará de los estudiantes.
+        const result = await pool.query('DELETE FROM groups WHERE group_id = $1', [id]);
+
+        if (result.rowCount === 0) {
+            return res.status(404).json({ message: 'Grupo no encontrado.' });
+        }
+
+        res.json({ message: 'Grupo eliminado exitosamente.' });
+    } catch (err) {
+        console.error('Error deleting group:', err.message);
+        res.status(500).send('Server error');
+    }
+});
+
+
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import TeacherAttendancePage from './pages/TeacherAttendancePage';
 import TeacherScoresPage from './pages/TeacherScoresPage';
 import TeacherReportsPage from './pages/TeacherReportsPage';
 import TeacherProfilePage from './pages/TeacherProfilePage';
+import GroupManagementPage from './pages/GroupManagementPage';
 import StudentLoginPage from './pages/StudentLoginPage';
 import StudentDashboardPage from './pages/StudentDashboardPage';
 import StudentScoresDetailPage from './pages/StudentScoresDetailPage';
@@ -115,6 +116,7 @@ function App() {
                 <Route path="/docente/asistencia-camara" element={<CameraAttendancePage />} />
                 <Route path="/docente/puntuaciones" element={<TeacherScoresPage />} />
                 <Route path="/docente/informes" element={<TeacherReportsPage />} />
+                <Route path="/docente/grupos" element={<GroupManagementPage />} />
                 <Route path="/docente/mi-perfil" element={<TeacherProfilePage />} />
               </Route>
             </Route>

--- a/frontend/src/pages/GroupManagementPage.jsx
+++ b/frontend/src/pages/GroupManagementPage.jsx
@@ -1,0 +1,190 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import axios from 'axios';
+import { Link } from 'react-router-dom';
+import { API_BASE_URL } from '../config';
+import ConfirmationModal from '../components/ConfirmationModal';
+
+const GroupManagementPage = () => {
+    const [groups, setGroups] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+    const [editingGroup, setEditingGroup] = useState(null);
+    const [newGroup, setNewGroup] = useState({ name: '', schedule_description: '' });
+
+    // State for delete confirmation modal
+    const [showDeleteModal, setShowDeleteModal] = useState(false);
+    const [groupToDelete, setGroupToDelete] = useState(null);
+
+    const getToken = useCallback(() => localStorage.getItem('teacherToken'), []);
+
+    const fetchGroups = useCallback(async () => {
+        try {
+            setLoading(true);
+            const token = getToken();
+            const { data } = await axios.get(`${API_BASE_URL}/groups`, {
+                headers: { 'x-auth-token': token }
+            });
+            setGroups(data);
+        } catch (err) {
+            setError('Error al cargar los grupos.');
+        } finally {
+            setLoading(false);
+        }
+    }, [getToken]);
+
+    useEffect(() => {
+        fetchGroups();
+    }, [fetchGroups]);
+
+    const handleCreate = async (e) => {
+        e.preventDefault();
+        if (!newGroup.name) {
+            setError('El nombre del grupo no puede estar vacío.');
+            return;
+        }
+        try {
+            const token = getToken();
+            const { data } = await axios.post(`${API_BASE_URL}/groups`, newGroup, {
+                headers: { 'x-auth-token': token }
+            });
+            setGroups([...groups, data]);
+            setNewGroup({ name: '', schedule_description: '' });
+            setError('');
+        } catch (err) {
+            setError(err.response?.data?.message || 'Error al crear el grupo.');
+        }
+    };
+
+    const handleUpdate = async (group) => {
+        if (!group.name) {
+            setError('El nombre del grupo no puede estar vacío.');
+            return;
+        }
+        try {
+            const token = getToken();
+            const { data } = await axios.put(`${API_BASE_URL}/groups/${group.group_id}`, group, {
+                headers: { 'x-auth-token': token }
+            });
+            setGroups(groups.map(g => (g.group_id === group.group_id ? data : g)));
+            setEditingGroup(null);
+            setError('');
+        } catch (err) {
+            setError(err.response?.data?.message || 'Error al actualizar el grupo.');
+        }
+    };
+
+    const handleDelete = (group) => {
+        setGroupToDelete(group);
+        setShowDeleteModal(true);
+    };
+
+    const confirmDelete = async () => {
+        if (!groupToDelete) return;
+        try {
+            const token = getToken();
+            await axios.delete(`${API_BASE_URL}/groups/${groupToDelete.group_id}`, {
+                headers: { 'x-auth-token': token }
+            });
+            setGroups(groups.filter(g => g.group_id !== groupToDelete.group_id));
+            setShowDeleteModal(false);
+            setGroupToDelete(null);
+        } catch (err) {
+            setError(err.response?.data?.message || 'Error al eliminar el grupo.');
+            setShowDeleteModal(false);
+        }
+    };
+
+    const renderGroupRow = (group) => {
+        const isEditing = editingGroup?.group_id === group.group_id;
+
+        return (
+            <tr key={group.group_id}>
+                <td>{isEditing ? <input type="text" value={editingGroup.name} onChange={(e) => setEditingGroup({...editingGroup, name: e.target.value})} /> : group.name}</td>
+                <td>{isEditing ? <input type="text" value={editingGroup.schedule_description} onChange={(e) => setEditingGroup({...editingGroup, schedule_description: e.target.value})} /> : group.schedule_description}</td>
+                <td className="actions-cell">
+                    {isEditing ? (
+                        <>
+                            <button onClick={() => handleUpdate(editingGroup)} className="btn-action btn-save">Guardar</button>
+                            <button onClick={() => setEditingGroup(null)} className="btn-action btn-cancel">Cancelar</button>
+                        </>
+                    ) : (
+                        <>
+                            <button onClick={() => setEditingGroup({...group})} className="btn-action btn-edit">Editar</button>
+                            <button onClick={() => handleDelete(group)} className="btn-action btn-delete">Eliminar</button>
+                        </>
+                    )}
+                </td>
+            </tr>
+        );
+    };
+
+    return (
+        <div className="content-page-container">
+            <div className="page-header-controls">
+                <Link to="/docente/dashboard" className="back-link">&larr; Volver al Panel</Link>
+            </div>
+            <h2 className="page-title">Gestionar Grupos</h2>
+
+            {error && <div className="error-message-page">{error}</div>}
+
+            <div className="card">
+                <h3 className="card-header">Crear Nuevo Grupo</h3>
+                <form onSubmit={handleCreate} className="card-content form-grid">
+                    <div className="form-group">
+                        <label htmlFor="new-group-name">Nombre del Grupo</label>
+                        <input
+                            id="new-group-name"
+                            type="text"
+                            value={newGroup.name}
+                            onChange={(e) => setNewGroup({ ...newGroup, name: e.target.value })}
+                            placeholder="Ej: Grupo de los Sábados"
+                        />
+                    </div>
+                    <div className="form-group">
+                        <label htmlFor="new-group-schedule">Descripción / Horario</label>
+                        <input
+                            id="new-group-schedule"
+                            type="text"
+                            value={newGroup.schedule_description}
+                            onChange={(e) => setNewGroup({ ...newGroup, schedule_description: e.target.value })}
+                            placeholder="Ej: Sábados de 3 a 5 PM"
+                        />
+                    </div>
+                    <div className="form-group">
+                        <button type="submit" className="btn-action btn-add-student">Crear Grupo</button>
+                    </div>
+                </form>
+            </div>
+
+            <div className="card" style={{ marginTop: '2rem' }}>
+                <h3 className="card-header">Lista de Grupos</h3>
+                <div className="card-content" style={{ overflowX: 'auto' }}>
+                    {loading ? <p>Cargando grupos...</p> : (
+                        <table className="styled-table">
+                            <thead>
+                                <tr>
+                                    <th>Nombre</th>
+                                    <th>Descripción / Horario</th>
+                                    <th>Acciones</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {groups.map(renderGroupRow)}
+                            </tbody>
+                        </table>
+                    )}
+                </div>
+            </div>
+
+            {showDeleteModal && (
+                <ConfirmationModal
+                    message={`¿Estás seguro de que quieres eliminar el grupo "${groupToDelete?.name}"? Esta acción no se puede deshacer.`}
+                    onConfirm={confirmDelete}
+                    onCancel={() => setShowDeleteModal(false)}
+                />
+            )}
+        </div>
+    );
+};
+
+export default GroupManagementPage;

--- a/frontend/src/pages/TeacherDashboardPage.jsx
+++ b/frontend/src/pages/TeacherDashboardPage.jsx
@@ -161,6 +161,7 @@ const TeacherDashboardPage = () => {
         <Link to="/docente/asistencia" className="dashboard-action-card">Registrar Asistencia</Link>
         <Link to="/docente/puntuaciones" className="dashboard-action-card">Registrar Puntuaciones</Link>
         <Link to="/docente/estudiantes" className="dashboard-action-card">Gestionar Estudiantes</Link>
+        <Link to="/docente/grupos" className="dashboard-action-card">Gestionar Grupos</Link>
         <Link to="/docente/informes" className="dashboard-action-card">Informes y Resúmenes</Link>
       </div>
 


### PR DESCRIPTION
This commit introduces two main features:

1.  **Group Management:**
    - Adds a new page for teachers to manage student groups (`/docente/grupos`).
    - Teachers can now create, rename (update), and delete groups directly from the UI.
    - Implements the necessary API endpoints (`POST`, `PUT`, `DELETE` on `/api/groups`) on the backend to support these operations.

2.  **Student Export Enhancement:**
    - On the "Reports" page, replaces the "simple/full" export mode with a flexible column selection feature using checkboxes.
    - Allows users to select exactly which columns they want to export.
    - Changes the export format to a tab-separated file with a `.xls` extension for better compatibility with Excel.